### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Add babel-runtime dependency
+- Added babel-runtime dependency
+- Bumped dependencies by `npm audit` in [PR #9](https://github.com/compulim/react-say/pull/9)
+   - `@babel/core@7.4.5` and related packages
+   - `jest@24.8.0`
+   - `lerna@3.14.1`
+   - `memoize-one@5.0.4`
+   - `react-scripts@3.0.1`
+   - `rimraf@2.6.3`
 
 ### Fixed
 - Fix [#8](https://github.com/compulim/react-say/issues/8) by removing workaround for Chrome bug, in [PR #7](https://github.com/compulim/react-say/pull/7)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,44 +4,973 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
+    "@lerna/add": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.14.0.tgz",
+      "integrity": "sha512-Sa79Ju6HqF3heSVpBiYPNrGtuS56U/jMzVq4CcVvhNwB34USLrzJJncGFVcfnuUvsjKeFJv+jHxUycHeRE8XYw==",
+      "dev": true,
+      "requires": {
+        "@lerna/bootstrap": "3.14.0",
+        "@lerna/command": "3.14.0",
+        "@lerna/filter-options": "3.14.0",
+        "@lerna/npm-conf": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "dedent": "^0.7.0",
+        "npm-package-arg": "^6.1.0",
+        "p-map": "^1.2.0",
+        "pacote": "^9.5.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/batch-packages": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.14.0.tgz",
+      "integrity": "sha512-RlBkQVNTqk1qvn6PFWiWNiskllUHh6tXbTVm43mZRNd+vhAyvrQC8RWJxH0ECVvnFAt9rSNGRIVbEJ31WnNQLg==",
+      "dev": true,
+      "requires": {
+        "@lerna/package-graph": "3.14.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/bootstrap": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.14.0.tgz",
+      "integrity": "sha512-AvnuDp8b0kX4zZgqD3v7ItPABhUsN5CmTEvZBD2JqM+xkQKhzCfz5ABcHEwDwOPWnNQmtH+/2iQdwaD7xBcAXw==",
+      "dev": true,
+      "requires": {
+        "@lerna/batch-packages": "3.14.0",
+        "@lerna/command": "3.14.0",
+        "@lerna/filter-options": "3.14.0",
+        "@lerna/has-npm-version": "3.13.3",
+        "@lerna/npm-install": "3.13.3",
+        "@lerna/package-graph": "3.14.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/rimraf-dir": "3.13.3",
+        "@lerna/run-lifecycle": "3.14.0",
+        "@lerna/run-parallel-batches": "3.13.0",
+        "@lerna/symlink-binary": "3.14.0",
+        "@lerna/symlink-dependencies": "3.14.0",
+        "@lerna/validation-error": "3.13.0",
+        "dedent": "^0.7.0",
+        "get-port": "^3.2.0",
+        "multimatch": "^2.1.0",
+        "npm-package-arg": "^6.1.0",
+        "npmlog": "^4.1.2",
+        "p-finally": "^1.0.0",
+        "p-map": "^1.2.0",
+        "p-map-series": "^1.0.0",
+        "p-waterfall": "^1.0.0",
+        "read-package-tree": "^5.1.6",
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/changed": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.14.1.tgz",
+      "integrity": "sha512-G0RgYL/WLTFzbezRBLUO2J0v39EvgZIO5bHHUtYt7zUFSfzapkPfvpdpBj+5JlMtf0B2xfxwTk+lSA4LVnbfmA==",
+      "dev": true,
+      "requires": {
+        "@lerna/collect-updates": "3.14.0",
+        "@lerna/command": "3.14.0",
+        "@lerna/listable": "3.14.0",
+        "@lerna/output": "3.13.0",
+        "@lerna/version": "3.14.1"
+      }
+    },
+    "@lerna/check-working-tree": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.14.1.tgz",
+      "integrity": "sha512-ae/sdZPNh4SS+6c4UDuWP/QKbtIFAn/TvKsPncA1Jdo0PqXLBlug4DzkHTGkvZ5F0nj+0JrSxYteInakJV99vg==",
+      "dev": true,
+      "requires": {
+        "@lerna/collect-uncommitted": "3.14.1",
+        "@lerna/describe-ref": "3.13.3",
+        "@lerna/validation-error": "3.13.0"
+      }
+    },
+    "@lerna/child-process": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.13.3.tgz",
+      "integrity": "sha512-3/e2uCLnbU+bydDnDwyadpOmuzazS01EcnOleAnuj9235CU2U97DH6OyoG1EW/fU59x11J+HjIqovh5vBaMQjQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.1",
+        "execa": "^1.0.0",
+        "strong-log-transformer": "^2.0.0"
+      }
+    },
+    "@lerna/clean": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.14.0.tgz",
+      "integrity": "sha512-wEuAqOS9VMqh2C20KD63IySzyEnyVDqDI3LUsXw+ByUf9AJDgEHv0TCOxbDjDYaaQw1tjSBNZMyYInNeoASwhA==",
+      "dev": true,
+      "requires": {
+        "@lerna/command": "3.14.0",
+        "@lerna/filter-options": "3.14.0",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/rimraf-dir": "3.13.3",
+        "p-map": "^1.2.0",
+        "p-map-series": "^1.0.0",
+        "p-waterfall": "^1.0.0"
+      }
+    },
+    "@lerna/cli": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz",
+      "integrity": "sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==",
+      "dev": true,
+      "requires": {
+        "@lerna/global-options": "3.13.0",
+        "dedent": "^0.7.0",
+        "npmlog": "^4.1.2",
+        "yargs": "^12.0.1"
+      }
+    },
+    "@lerna/collect-uncommitted": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.14.1.tgz",
+      "integrity": "sha512-hQ67S+nlSJwsPylXbWlrQSZUcWa8tTNIdcMd9OY4+QxdJlZUG7CLbWSyaxi0g11WdoRJHT163mr9xQyAvIVT1A==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "chalk": "^2.3.1",
+        "figgy-pudding": "^3.5.1",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/collect-updates": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.14.0.tgz",
+      "integrity": "sha512-siRHo2atAwj5KpKVOo6QTVIYDYbNs7dzTG6ow9VcFMLKX5shuaEyFA22Z3LmnxQ3sakVFdgvvVeediEz6cM3VA==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "@lerna/describe-ref": "3.13.3",
+        "minimatch": "^3.0.4",
+        "npmlog": "^4.1.2",
+        "slash": "^1.0.0"
+      }
+    },
+    "@lerna/command": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.14.0.tgz",
+      "integrity": "sha512-PtFi5EtXB2VuSruoLsjfZdus56d7oKlZAI4iSRoaS/BBxE2Wyfn7//vW7Ow4hZCzuqb9tBcpDq+4u2pdXN1d2Q==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "@lerna/package-graph": "3.14.0",
+        "@lerna/project": "3.13.1",
+        "@lerna/validation-error": "3.13.0",
+        "@lerna/write-log-file": "3.13.0",
+        "dedent": "^0.7.0",
+        "execa": "^1.0.0",
+        "is-ci": "^1.0.10",
+        "lodash": "^4.17.5",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/conventional-commits": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.14.0.tgz",
+      "integrity": "sha512-hGZ2qQZ9uEGf2eeIiIpEodSs9Qkkf/2uYEtNT7QN1RYISPUh6/lKGBssc5dpbCF64aEuxmemWLdlDf1ogG6++w==",
+      "dev": true,
+      "requires": {
+        "@lerna/validation-error": "3.13.0",
+        "conventional-changelog-angular": "^5.0.3",
+        "conventional-changelog-core": "^3.1.6",
+        "conventional-recommended-bump": "^4.0.4",
+        "fs-extra": "^7.0.0",
+        "get-stream": "^4.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npmlog": "^4.1.2",
+        "pify": "^3.0.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/create": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.14.0.tgz",
+      "integrity": "sha512-J4PeGnzVBOSV7Cih8Uhv9xIauljR9bGcfSDN9aMzFtJhSX0xFXNvmnpXRORp7xNHV2lbxk7mNxRQxzR9CQRMuw==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "@lerna/command": "3.14.0",
+        "@lerna/npm-conf": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "camelcase": "^5.0.0",
+        "dedent": "^0.7.0",
+        "fs-extra": "^7.0.0",
+        "globby": "^8.0.1",
+        "init-package-json": "^1.10.3",
+        "npm-package-arg": "^6.1.0",
+        "p-reduce": "^1.0.0",
+        "pacote": "^9.5.0",
+        "pify": "^3.0.0",
+        "semver": "^5.5.0",
+        "slash": "^1.0.0",
+        "validate-npm-package-license": "^3.0.3",
+        "validate-npm-package-name": "^3.0.0",
+        "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/create-symlink": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.14.0.tgz",
+      "integrity": "sha512-Kw51HYOOi6UfCKncqkgEU1k/SYueSBXgkNL91FR8HAZH7EPSRTEtp9mnJo568g0+Hog5C+3cOaWySwhHpRG29A==",
+      "dev": true,
+      "requires": {
+        "cmd-shim": "^2.0.2",
+        "fs-extra": "^7.0.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/describe-ref": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.13.3.tgz",
+      "integrity": "sha512-5KcLTvjdS4gU5evW8ESbZ0BF44NM5HrP3dQNtWnOUSKJRgsES8Gj0lq9AlB2+YglZfjEftFT03uOYOxnKto4Uw==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/diff": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.14.0.tgz",
+      "integrity": "sha512-H6FSj0jOiQ6unVCwOK6ReT5uZN6ZIn/j/cx4YwuOtU3SMcs3UfuQRIFNeKg/tKmOcQGd39Mn9zDhmt3TAYGROA==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "@lerna/command": "3.14.0",
+        "@lerna/validation-error": "3.13.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/exec": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.14.0.tgz",
+      "integrity": "sha512-cNFO8hWsBVLeqVQ7LsQ4rYKbbQ2eN+Ne+hWKTlUQoyRbYzgJ22TXhjKR6IMr68q0xtclcDlasfcNO+XEWESh0g==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "@lerna/command": "3.14.0",
+        "@lerna/filter-options": "3.14.0",
+        "@lerna/run-topologically": "3.14.0",
+        "@lerna/validation-error": "3.13.0",
+        "p-map": "^1.2.0"
+      }
+    },
+    "@lerna/filter-options": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.14.0.tgz",
+      "integrity": "sha512-ZmNZK9m8evxHc+2ZnDyCm8XFIKVDKpIASG1wtizr3R14t49fuYE7nR+rm4t82u9oSSmER8gb8bGzh0SKZme/jg==",
+      "dev": true,
+      "requires": {
+        "@lerna/collect-updates": "3.14.0",
+        "@lerna/filter-packages": "3.13.0",
+        "dedent": "^0.7.0"
+      }
+    },
+    "@lerna/filter-packages": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.13.0.tgz",
+      "integrity": "sha512-RWiZWyGy3Mp7GRVBn//CacSnE3Kw82PxE4+H6bQ3pDUw/9atXn7NRX+gkBVQIYeKamh7HyumJtyOKq3Pp9BADQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/validation-error": "3.13.0",
+        "multimatch": "^2.1.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/get-npm-exec-opts": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.13.0.tgz",
+      "integrity": "sha512-Y0xWL0rg3boVyJk6An/vurKzubyJKtrxYv2sj4bB8Mc5zZ3tqtv0ccbOkmkXKqbzvNNF7VeUt1OJ3DRgtC/QZw==",
+      "dev": true,
+      "requires": {
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/get-packed": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.13.0.tgz",
+      "integrity": "sha512-EgSim24sjIjqQDC57bgXD9l22/HCS93uQBbGpkzEOzxAVzEgpZVm7Fm1t8BVlRcT2P2zwGnRadIvxTbpQuDPTg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "ssri": "^6.0.1",
+        "tar": "^4.4.8"
+      }
+    },
+    "@lerna/github-client": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.13.3.tgz",
+      "integrity": "sha512-fcJkjab4kX0zcLLSa/DCUNvU3v8wmy2c1lhdIbL7s7gABmDcV0QZq93LhnEee3VkC9UpnJ6GKG4EkD7eIifBnA==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "@octokit/plugin-enterprise-rest": "^2.1.1",
+        "@octokit/rest": "^16.16.0",
+        "git-url-parse": "^11.1.2",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/global-options": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.13.0.tgz",
+      "integrity": "sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==",
+      "dev": true
+    },
+    "@lerna/has-npm-version": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.13.3.tgz",
+      "integrity": "sha512-mQzoghRw4dBg0R9FFfHrj0TH0glvXyzdEZmYZ8Isvx5BSuEEwpsryoywuZSdppcvLu8o7NAdU5Tac8cJ/mT52w==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/import": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.14.0.tgz",
+      "integrity": "sha512-j8z/m85FX1QYPgl5TzMNupdxsQF/NFZSmdCR19HQzqiVKC8ULGzF30WJEk66+KeZ94wYMSakINtYD+41s34pNQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "@lerna/command": "3.14.0",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "dedent": "^0.7.0",
+        "fs-extra": "^7.0.0",
+        "p-map-series": "^1.0.0"
+      }
+    },
+    "@lerna/init": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.14.0.tgz",
+      "integrity": "sha512-X3PQkQZds5ozA1xiarmVzAK6LPLNK3bBu24Api0w2KJXO7Ccs9ob/VcGdevZuzqdJo1Xg2H6oBhEqIClU9Uqqw==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "@lerna/command": "3.14.0",
+        "fs-extra": "^7.0.0",
+        "p-map": "^1.2.0",
+        "write-json-file": "^2.3.0"
+      }
+    },
+    "@lerna/link": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.14.0.tgz",
+      "integrity": "sha512-xlwQhWTVOZrgAuoONY3/OIBWehDfZXmf5qFhnOy7lIxByRhEX5Vwx0ApaGxHTv3Flv7T+oI4s8UZVq5F6dT8Aw==",
+      "dev": true,
+      "requires": {
+        "@lerna/command": "3.14.0",
+        "@lerna/package-graph": "3.14.0",
+        "@lerna/symlink-dependencies": "3.14.0",
+        "p-map": "^1.2.0",
+        "slash": "^1.0.0"
+      }
+    },
+    "@lerna/list": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.14.0.tgz",
+      "integrity": "sha512-Gp+9gaIkBfXBwc9Ng0Y74IEfAqpQpLiXwOP4IOpdINxOeDpllhMaYP6SzLaMvrfSyHRayM7Cq5/PRnHkXQ5uuQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/command": "3.14.0",
+        "@lerna/filter-options": "3.14.0",
+        "@lerna/listable": "3.14.0",
+        "@lerna/output": "3.13.0"
+      }
+    },
+    "@lerna/listable": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.14.0.tgz",
+      "integrity": "sha512-ZK44Mo8xf/N97eQZ236SPSq0ek6+gk4HqHIx05foEMZVV1iIDH4a/nblLsJNjGQVsIdMYFPaqNJ0z+ZQfiJazQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/query-graph": "3.14.0",
+        "chalk": "^2.3.1",
+        "columnify": "^1.5.4"
+      }
+    },
+    "@lerna/log-packed": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.13.0.tgz",
+      "integrity": "sha512-Rmjrcz+6aM6AEcEVWmurbo8+AnHOvYtDpoeMMJh9IZ9SmZr2ClXzmD7wSvjTQc8BwOaiWjjC/ukcT0UYA2m7wg==",
+      "dev": true,
+      "requires": {
+        "byte-size": "^4.0.3",
+        "columnify": "^1.5.4",
+        "has-unicode": "^2.0.1",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/npm-conf": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.13.0.tgz",
+      "integrity": "sha512-Jg2kANsGnhg+fbPEzE0X9nX5oviEAvWj0nYyOkcE+cgWuT7W0zpnPXC4hA4C5IPQGhwhhh0IxhWNNHtjTuw53g==",
+      "dev": true,
+      "requires": {
+        "config-chain": "^1.1.11",
+        "pify": "^3.0.0"
+      }
+    },
+    "@lerna/npm-dist-tag": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.14.0.tgz",
+      "integrity": "sha512-DEyYEdufTGIC6E4RTJUsYPgqlz1Bs/XPeEQ5fd+ojWnICevj7dRrr2DfHucPiUCADlm2jbAraAQc3QPU0dXRhw==",
+      "dev": true,
+      "requires": {
+        "@lerna/otplease": "3.14.0",
+        "figgy-pudding": "^3.5.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.9.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/npm-install": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.13.3.tgz",
+      "integrity": "sha512-7Jig9MLpwAfcsdQ5UeanAjndChUjiTjTp50zJ+UZz4CbIBIDhoBehvNMTCL2G6pOEC7sGEg6sAqJINAqred6Tg==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "@lerna/get-npm-exec-opts": "3.13.0",
+        "fs-extra": "^7.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npmlog": "^4.1.2",
+        "signal-exit": "^3.0.2",
+        "write-pkg": "^3.1.0"
+      }
+    },
+    "@lerna/npm-publish": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.14.0.tgz",
+      "integrity": "sha512-ShG0qEnGkWxtjQvIRATgm/CzeoVaSyyoNRag5t8gDSR/r2u9ux72oROKQUEaE8OwcTS4rL2cyBECts8XMNmyYw==",
+      "dev": true,
+      "requires": {
+        "@lerna/otplease": "3.14.0",
+        "@lerna/run-lifecycle": "3.14.0",
+        "figgy-pudding": "^3.5.1",
+        "fs-extra": "^7.0.0",
+        "libnpmpublish": "^1.1.1",
+        "npm-package-arg": "^6.1.0",
+        "npmlog": "^4.1.2",
+        "pify": "^3.0.0",
+        "read-package-json": "^2.0.13"
+      }
+    },
+    "@lerna/npm-run-script": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.13.3.tgz",
+      "integrity": "sha512-qR4o9BFt5hI8Od5/DqLalOJydnKpiQFEeN0h9xZi7MwzuX1Ukwh3X22vqsX4YRbipIelSFtrDzleNVUm5jj0ow==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "@lerna/get-npm-exec-opts": "3.13.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/otplease": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/otplease/-/otplease-3.14.0.tgz",
+      "integrity": "sha512-rYAWzaYZ81bwnrmTkYWGgcc13bl/6DlG7pjWQWNGAJNLzO5zzj0xmXN5sMFJnNvDpSiS/ZS1sIuPvb4xnwLUkg==",
+      "dev": true,
+      "requires": {
+        "@lerna/prompt": "3.13.0",
+        "figgy-pudding": "^3.5.1"
+      }
+    },
+    "@lerna/output": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.13.0.tgz",
+      "integrity": "sha512-7ZnQ9nvUDu/WD+bNsypmPG5MwZBwu86iRoiW6C1WBuXXDxM5cnIAC1m2WxHeFnjyMrYlRXM9PzOQ9VDD+C15Rg==",
+      "dev": true,
+      "requires": {
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/pack-directory": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.14.0.tgz",
+      "integrity": "sha512-E9PmC1oWYjYN8Z0Oeoj7X98NruMg/pcdDiRxnwJ5awnB0d/kyfoquHXCYwCQQFCnWUfto7m5lM4CSostcolEVQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/get-packed": "3.13.0",
+        "@lerna/package": "3.13.0",
+        "@lerna/run-lifecycle": "3.14.0",
+        "figgy-pudding": "^3.5.1",
+        "npm-packlist": "^1.4.1",
+        "npmlog": "^4.1.2",
+        "tar": "^4.4.8",
+        "temp-write": "^3.4.0"
+      }
+    },
+    "@lerna/package": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.13.0.tgz",
+      "integrity": "sha512-kSKO0RJQy093BufCQnkhf1jB4kZnBvL7kK5Ewolhk5gwejN+Jofjd8DGRVUDUJfQ0CkW1o6GbUeZvs8w8VIZDg==",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "npm-package-arg": "^6.1.0",
+        "write-pkg": "^3.1.0"
+      }
+    },
+    "@lerna/package-graph": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.14.0.tgz",
+      "integrity": "sha512-dNpA/64STD5YXhaSlg4gT6Z474WPJVCHoX1ibsVIFu0fVgH609Y69bsdmbvTRdI7r6Dcu4ZfGxdR636RTrH+Eg==",
+      "dev": true,
+      "requires": {
+        "@lerna/prerelease-id-from-version": "3.14.0",
+        "@lerna/validation-error": "3.13.0",
+        "npm-package-arg": "^6.1.0",
+        "npmlog": "^4.1.2",
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/prerelease-id-from-version": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/prerelease-id-from-version/-/prerelease-id-from-version-3.14.0.tgz",
+      "integrity": "sha512-Ap3Z/dNhqQuSrKmK+JmzYvQYI2vowxHvUVxZJiDVilW8dyNnxkCsYFmkuZytk5sxVz4VeGLNPS2RSsU5eeSS+Q==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/project": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.13.1.tgz",
+      "integrity": "sha512-/GoCrpsCCTyb9sizk1+pMBrIYchtb+F1uCOn3cjn9yenyG/MfYEnlfrbV5k/UDud0Ei75YBLbmwCbigHkAKazQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/package": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "cosmiconfig": "^5.1.0",
+        "dedent": "^0.7.0",
+        "dot-prop": "^4.2.0",
+        "glob-parent": "^3.1.0",
+        "globby": "^8.0.1",
+        "load-json-file": "^4.0.0",
+        "npmlog": "^4.1.2",
+        "p-map": "^1.2.0",
+        "resolve-from": "^4.0.0",
+        "write-json-file": "^2.3.0"
+      }
+    },
+    "@lerna/prompt": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.13.0.tgz",
+      "integrity": "sha512-P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==",
+      "dev": true,
+      "requires": {
+        "inquirer": "^6.2.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/publish": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.14.1.tgz",
+      "integrity": "sha512-p+By/P84XJkndBzrmcnVLMcFpGAE+sQZCQK4e3aKQrEMLDrEwXkWt/XJxzeQskPxInFA/7Icj686LOADO7p0qg==",
+      "dev": true,
+      "requires": {
+        "@lerna/check-working-tree": "3.14.1",
+        "@lerna/child-process": "3.13.3",
+        "@lerna/collect-updates": "3.14.0",
+        "@lerna/command": "3.14.0",
+        "@lerna/describe-ref": "3.13.3",
+        "@lerna/log-packed": "3.13.0",
+        "@lerna/npm-conf": "3.13.0",
+        "@lerna/npm-dist-tag": "3.14.0",
+        "@lerna/npm-publish": "3.14.0",
+        "@lerna/output": "3.13.0",
+        "@lerna/pack-directory": "3.14.0",
+        "@lerna/prerelease-id-from-version": "3.14.0",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/run-lifecycle": "3.14.0",
+        "@lerna/run-topologically": "3.14.0",
+        "@lerna/validation-error": "3.13.0",
+        "@lerna/version": "3.14.1",
+        "figgy-pudding": "^3.5.1",
+        "fs-extra": "^7.0.0",
+        "libnpmaccess": "^3.0.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.9.0",
+        "npmlog": "^4.1.2",
+        "p-finally": "^1.0.0",
+        "p-map": "^1.2.0",
+        "p-pipe": "^1.2.0",
+        "pacote": "^9.5.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/pulse-till-done": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/pulse-till-done/-/pulse-till-done-3.13.0.tgz",
+      "integrity": "sha512-1SOHpy7ZNTPulzIbargrgaJX387csN7cF1cLOGZiJQA6VqnS5eWs2CIrG8i8wmaUavj2QlQ5oEbRMVVXSsGrzA==",
+      "dev": true,
+      "requires": {
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/query-graph": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.14.0.tgz",
+      "integrity": "sha512-6YTh3vDMW2hUxHdKeRvx4bosc9lZClKaN+DzC1XKTkwDbWrsjmEzLcemKL6QnyyeuryN2f/eto7P9iSe3z3pQQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/package-graph": "3.14.0",
+        "figgy-pudding": "^3.5.1"
+      }
+    },
+    "@lerna/resolve-symlink": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.13.0.tgz",
+      "integrity": "sha512-Lc0USSFxwDxUs5JvIisS8JegjA6SHSAWJCMvi2osZx6wVRkEDlWG2B1JAfXUzCMNfHoZX0/XX9iYZ+4JIpjAtg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "npmlog": "^4.1.2",
+        "read-cmd-shim": "^1.0.1"
+      }
+    },
+    "@lerna/rimraf-dir": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.13.3.tgz",
+      "integrity": "sha512-d0T1Hxwu3gpYVv73ytSL+/Oy8JitsmvOYUR5ouRSABsmqS7ZZCh5t6FgVDDGVXeuhbw82+vuny1Og6Q0k4ilqw==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.3",
+        "npmlog": "^4.1.2",
+        "path-exists": "^3.0.0",
+        "rimraf": "^2.6.2"
+      }
+    },
+    "@lerna/run": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.14.0.tgz",
+      "integrity": "sha512-kGGFGLYPKozAN07CSJ7kOyLY6W3oLCQcxCathg1isSkBqQH29tWUg8qNduOlhIFLmnq/nf1JEJxxoXnF6IRLjQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/command": "3.14.0",
+        "@lerna/filter-options": "3.14.0",
+        "@lerna/npm-run-script": "3.13.3",
+        "@lerna/output": "3.13.0",
+        "@lerna/run-topologically": "3.14.0",
+        "@lerna/timer": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "p-map": "^1.2.0"
+      }
+    },
+    "@lerna/run-lifecycle": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.14.0.tgz",
+      "integrity": "sha512-GUM3L9MzGRSW0WQ8wbLW1+SYStU1OFjW0GBzShhBnFrO4nGRrU7VchsLpcLu0hk2uCzyhsrDKzifEdOdUyMoEQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/npm-conf": "3.13.0",
+        "figgy-pudding": "^3.5.1",
+        "npm-lifecycle": "^2.1.1",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/run-parallel-batches": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.13.0.tgz",
+      "integrity": "sha512-bICFBR+cYVF1FFW+Tlm0EhWDioTUTM6dOiVziDEGE1UZha1dFkMYqzqdSf4bQzfLS31UW/KBd/2z8jy2OIjEjg==",
+      "dev": true,
+      "requires": {
+        "p-map": "^1.2.0",
+        "p-map-series": "^1.0.0"
+      }
+    },
+    "@lerna/run-topologically": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.14.0.tgz",
+      "integrity": "sha512-y+KBpC1YExFzGynovt9MY4O/bc3RrJaKeuXieiPfKGKxrdtmZe/r33oj/xePTXZq65jnw3SaU3H8S5CrrdkwDg==",
+      "dev": true,
+      "requires": {
+        "@lerna/query-graph": "3.14.0",
+        "figgy-pudding": "^3.5.1",
+        "p-queue": "^4.0.0"
+      }
+    },
+    "@lerna/symlink-binary": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.14.0.tgz",
+      "integrity": "sha512-AHFb4NlazxYmC+7guoamM3laIRbMSeKERMooKHJ7moe0ayGPBWsCGOH+ZFKZ+eXSDek+FnxdzayR3wf8B3LkTg==",
+      "dev": true,
+      "requires": {
+        "@lerna/create-symlink": "3.14.0",
+        "@lerna/package": "3.13.0",
+        "fs-extra": "^7.0.0",
+        "p-map": "^1.2.0"
+      }
+    },
+    "@lerna/symlink-dependencies": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.14.0.tgz",
+      "integrity": "sha512-kuSXxwAWiVZqFcXfUBKH4yLUH3lrnGyZmCYon7UnZitw3AK3LQY7HvV2LNNw/oatfjOAiKhPBxnYjYijKiV4oA==",
+      "dev": true,
+      "requires": {
+        "@lerna/create-symlink": "3.14.0",
+        "@lerna/resolve-symlink": "3.13.0",
+        "@lerna/symlink-binary": "3.14.0",
+        "fs-extra": "^7.0.0",
+        "p-finally": "^1.0.0",
+        "p-map": "^1.2.0",
+        "p-map-series": "^1.0.0"
+      }
+    },
+    "@lerna/timer": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/timer/-/timer-3.13.0.tgz",
+      "integrity": "sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw==",
+      "dev": true
+    },
+    "@lerna/validation-error": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.13.0.tgz",
+      "integrity": "sha512-SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==",
+      "dev": true,
+      "requires": {
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/version": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.14.1.tgz",
+      "integrity": "sha512-H/jykoxVIt4oDEYkBgwDfO5dmZFl3G6vP1UEttRVP1FIkI+gCN+olby8S0Qd8XprDuR5OrLboiDWQs3p7nJhLw==",
+      "dev": true,
+      "requires": {
+        "@lerna/batch-packages": "3.14.0",
+        "@lerna/check-working-tree": "3.14.1",
+        "@lerna/child-process": "3.13.3",
+        "@lerna/collect-updates": "3.14.0",
+        "@lerna/command": "3.14.0",
+        "@lerna/conventional-commits": "3.14.0",
+        "@lerna/github-client": "3.13.3",
+        "@lerna/output": "3.13.0",
+        "@lerna/prerelease-id-from-version": "3.14.0",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/run-lifecycle": "3.14.0",
+        "@lerna/run-topologically": "3.14.0",
+        "@lerna/validation-error": "3.13.0",
+        "chalk": "^2.3.1",
+        "dedent": "^0.7.0",
+        "minimatch": "^3.0.4",
+        "npmlog": "^4.1.2",
+        "p-map": "^1.2.0",
+        "p-pipe": "^1.2.0",
+        "p-reduce": "^1.0.0",
+        "p-waterfall": "^1.0.0",
+        "semver": "^5.5.0",
+        "slash": "^1.0.0",
+        "temp-write": "^3.4.0"
+      }
+    },
+    "@lerna/write-log-file": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.13.0.tgz",
+      "integrity": "sha512-RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==",
+      "dev": true,
+      "requires": {
+        "npmlog": "^4.1.2",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "dev": true
+    },
+    "@octokit/endpoint": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.1.3.tgz",
+      "integrity": "sha512-ePx9kcUo0agRk0HaXhl+pKMXpBH1O3CAygwWIh7GT5i5kcUr8QowS0GBaZPirr1e0PqaFYr41hQfcUBA1R5AEQ==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "3.2.0",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^2.1.0",
+        "url-template": "^2.0.8"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/plugin-enterprise-rest": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.2.2.tgz",
+      "integrity": "sha512-CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw==",
+      "dev": true
+    },
+    "@octokit/request": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-4.1.0.tgz",
+      "integrity": "sha512-RvpQAba4i+BNH0z8i0gPRc1ShlHidj4puQjI/Tno6s+Q3/Mzb0XRSHJiOhpeFrZ22V7Mwjq1E7QS27P5CgpWYA==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^5.1.0",
+        "@octokit/request-error": "^1.0.1",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^2.1.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.2.tgz",
+      "integrity": "sha512-T9swMS/Vc4QlfWrvyeSyp/GjhXtYaBzCcibjGywV4k4D2qVrQKfEMPy8OxMDEj7zkIIdpHwqdpVbKCvnUPqkXw==",
+      "dev": true,
+      "requires": {
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.27.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.27.0.tgz",
+      "integrity": "sha512-UvCxVOCfHzEhOaltSKQBy81kMqQ+hglF3rAR4STut4WWr2tXvVnrIkGxeblO0TvmTt5zuxfgQfgG5kAHUT44RA==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^4.0.1",
+        "@octokit/request-error": "^1.0.2",
+        "atob-lite": "^2.0.0",
+        "before-after-hook": "^1.4.0",
+        "btoa-lite": "^1.0.0",
+        "deprecation": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^2.0.0",
+        "url-template": "^2.0.8"
+      }
+    },
     "JSONStream": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
-      "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dev": true,
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
       }
     },
-    "add-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-      "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "es6-promisify": "^5.0.0"
       }
     },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+    "agentkeepalive": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+      "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+      "dev": true,
+      "requires": {
+        "humanize-ms": "^1.2.1"
+      }
+    },
+    "ajv": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
     },
     "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -49,6 +978,15 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "aproba": {
       "version": "1.2.0",
@@ -65,6 +1003,39 @@
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
       }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -93,6 +1064,12 @@
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -104,26 +1081,137 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
-        }
+        "safer-buffer": "~2.1.0"
       }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "before-after-hook": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+      "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true
     },
     "bowser": {
@@ -141,16 +1229,51 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+    "builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
     "byline": {
@@ -159,12 +1282,86 @@
       "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
       "dev": true
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+    "byte-size": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.4.tgz",
+      "integrity": "sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw==",
+      "dev": true
+    },
+    "cacache": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+      "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "bluebird": "^3.5.3",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "requires": {
+        "callsites": "^2.0.0"
+      }
+    },
+    "caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "dev": true,
+      "requires": {
+        "caller-callsite": "^2.0.0"
+      }
+    },
+    "callsites": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "4.2.0",
@@ -175,44 +1372,65 @@
         "camelcase": "^4.1.0",
         "map-obj": "^2.0.0",
         "quick-lru": "^1.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        }
       }
     },
-    "capture-stack-trace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "chownr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "dev": true
     },
     "ci-info": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.4.0.tgz",
-      "integrity": "sha512-Oqmw2pVfCl8sCL+1QgMywPfdxPJPkC51y4usw0iiE2S9qnEOAqXy8bwl1CpMpnoU39g4iKJTz6QZj+28FvOnjQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
     },
     "classnames": {
       "version": "2.2.6",
@@ -235,23 +1453,46 @@
       "dev": true
     },
     "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
-          "optional": true
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
         }
       }
     },
@@ -276,6 +1517,16 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -302,11 +1553,21 @@
         "wcwidth": "^1.0.0"
       }
     },
-    "command-join": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
-      "integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=",
-      "dev": true
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true,
+      "optional": true
     },
     "compare-func": {
       "version": "1.3.2",
@@ -316,7 +1577,24 @@
       "requires": {
         "array-ify": "^1.0.0",
         "dot-prop": "^3.0.0"
+      },
+      "dependencies": {
+        "dot-prop": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        }
       }
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -336,354 +1614,201 @@
         "typedarray": "^0.0.6"
       }
     },
+    "config-chain": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
-    "conventional-changelog": {
-      "version": "1.1.24",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
-      "integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
-      "dev": true,
-      "requires": {
-        "conventional-changelog-angular": "^1.6.6",
-        "conventional-changelog-atom": "^0.2.8",
-        "conventional-changelog-codemirror": "^0.3.8",
-        "conventional-changelog-core": "^2.0.11",
-        "conventional-changelog-ember": "^0.3.12",
-        "conventional-changelog-eslint": "^1.0.9",
-        "conventional-changelog-express": "^0.3.6",
-        "conventional-changelog-jquery": "^0.1.0",
-        "conventional-changelog-jscs": "^0.1.0",
-        "conventional-changelog-jshint": "^0.3.8",
-        "conventional-changelog-preset-loader": "^1.1.8"
-      }
-    },
     "conventional-changelog-angular": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
-      "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
+      "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
-        "q": "^1.5.1"
-      }
-    },
-    "conventional-changelog-atom": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
-      "integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
-      "dev": true,
-      "requires": {
-        "q": "^1.5.1"
-      }
-    },
-    "conventional-changelog-cli": {
-      "version": "1.3.22",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.22.tgz",
-      "integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
-      "dev": true,
-      "requires": {
-        "add-stream": "^1.0.0",
-        "conventional-changelog": "^1.1.24",
-        "lodash": "^4.2.1",
-        "meow": "^4.0.0",
-        "tempfile": "^1.1.1"
-      }
-    },
-    "conventional-changelog-codemirror": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
-      "integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
-      "dev": true,
-      "requires": {
         "q": "^1.5.1"
       }
     },
     "conventional-changelog-core": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
-      "integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.2.2.tgz",
+      "integrity": "sha512-cssjAKajxaOX5LNAJLB+UOcoWjAIBvXtDMedv/58G+YEmAXMNfC16mmPl0JDOuVJVfIqM0nqQiZ8UCm8IXbE0g==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "^3.0.9",
-        "conventional-commits-parser": "^2.1.7",
+        "conventional-changelog-writer": "^4.0.5",
+        "conventional-commits-parser": "^3.0.2",
         "dateformat": "^3.0.0",
         "get-pkg-repo": "^1.0.0",
-        "git-raw-commits": "^1.3.6",
+        "git-raw-commits": "2.0.0",
         "git-remote-origin-url": "^2.0.0",
-        "git-semver-tags": "^1.3.6",
+        "git-semver-tags": "^2.0.2",
         "lodash": "^4.2.1",
         "normalize-package-data": "^2.3.5",
         "q": "^1.5.1",
-        "read-pkg": "^1.1.0",
-        "read-pkg-up": "^1.0.1",
-        "through2": "^2.0.0"
+        "read-pkg": "^3.0.0",
+        "read-pkg-up": "^3.0.0",
+        "through2": "^3.0.0"
       },
       "dependencies": {
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
+            "readable-stream": "2 || 3"
           }
         }
       }
     },
-    "conventional-changelog-ember": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
-      "integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
-      "dev": true,
-      "requires": {
-        "q": "^1.5.1"
-      }
-    },
-    "conventional-changelog-eslint": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
-      "integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
-      "dev": true,
-      "requires": {
-        "q": "^1.5.1"
-      }
-    },
-    "conventional-changelog-express": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
-      "integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
-      "dev": true,
-      "requires": {
-        "q": "^1.5.1"
-      }
-    },
-    "conventional-changelog-jquery": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
-      "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-      "dev": true,
-      "requires": {
-        "q": "^1.4.1"
-      }
-    },
-    "conventional-changelog-jscs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
-      "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-      "dev": true,
-      "requires": {
-        "q": "^1.4.1"
-      }
-    },
-    "conventional-changelog-jshint": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
-      "integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
-      "dev": true,
-      "requires": {
-        "compare-func": "^1.3.1",
-        "q": "^1.5.1"
-      }
-    },
     "conventional-changelog-preset-loader": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
-      "integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.1.1.tgz",
+      "integrity": "sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA==",
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
-      "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.6.tgz",
+      "integrity": "sha512-ou/sbrplJMM6KQpR5rKFYNVQYesFjN7WpNGdudQSWNi6X+RgyFUcSv871YBYkrUYV9EX8ijMohYVzn9RUb+4ag==",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
-        "conventional-commits-filter": "^1.1.6",
+        "conventional-commits-filter": "^2.0.2",
         "dateformat": "^3.0.0",
-        "handlebars": "^4.0.2",
+        "handlebars": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.2.1",
         "meow": "^4.0.0",
-        "semver": "^5.5.0",
+        "semver": "^6.0.0",
         "split": "^1.0.0",
-        "through2": "^2.0.0"
+        "through2": "^3.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+          "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+          "dev": true
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
       }
     },
     "conventional-commits-filter": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
-      "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz",
+      "integrity": "sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==",
       "dev": true,
       "requires": {
-        "is-subset": "^0.1.1",
+        "lodash.ismatch": "^4.4.0",
         "modify-values": "^1.0.0"
       }
     },
     "conventional-commits-parser": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
-      "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.3.tgz",
+      "integrity": "sha512-KaA/2EeUkO4bKjinNfGUyqPTX/6w9JGshuQRik4r/wJz7rUw3+D3fDG6sZSEqJvKILzKXFQuFkpPLclcsAuZcg==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
-        "is-text-path": "^1.0.0",
+        "is-text-path": "^2.0.0",
         "lodash": "^4.2.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
-        "through2": "^2.0.0",
+        "through2": "^3.0.0",
         "trim-off-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
       }
     },
     "conventional-recommended-bump": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
-      "integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.1.1.tgz",
+      "integrity": "sha512-JT2vKfSP9kR18RXXf55BRY1O3AHG8FPg5btP3l7LYfcWJsiXI6MCf30DepQ98E8Qhowvgv7a8iev0J1bEDkTFA==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.4.10",
-        "conventional-commits-filter": "^1.1.1",
-        "conventional-commits-parser": "^2.1.1",
-        "git-raw-commits": "^1.3.0",
-        "git-semver-tags": "^1.3.0",
-        "meow": "^3.3.0",
-        "object-assign": "^4.0.1"
+        "concat-stream": "^2.0.0",
+        "conventional-changelog-preset-loader": "^2.1.1",
+        "conventional-commits-filter": "^2.0.2",
+        "conventional-commits-parser": "^3.0.2",
+        "git-raw-commits": "2.0.0",
+        "git-semver-tags": "^2.0.2",
+        "meow": "^4.0.0",
+        "q": "^1.5.1"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
           "dev": true,
           "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
           }
         },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
         }
       }
+    },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
     },
     "core-js": {
       "version": "1.2.7",
@@ -696,22 +1821,27 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+    "cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
@@ -734,6 +1864,12 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "dev": true
+    },
     "dargs": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
@@ -743,10 +1879,34 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true
     },
     "decamelize": {
@@ -773,16 +1933,22 @@
         }
       }
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+    "deepmerge": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
       "dev": true
     },
     "defaults": {
@@ -794,16 +1960,95 @@
         "clone": "^1.0.2"
       }
     },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
+    "deprecation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.0.0.tgz",
+      "integrity": "sha512-lbQN037mB3VfA2JFuguM5GCJ+zPinMeCrFe+AfSZ6eqrnJA/Fs+EYMnd6Nb2mn9lf2jO9xwEd9o9lic+D4vkcw==",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+      "dev": true
+    },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "dir-glob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
+      }
+    },
     "dot-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
@@ -815,11 +2060,27 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "encoding": {
       "version": "0.1.12",
@@ -828,6 +2089,21 @@
       "requires": {
         "iconv-lite": "~0.4.13"
       }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -838,10 +2114,31 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "event-as-promise": {
@@ -849,14 +2146,20 @@
       "resolved": "https://registry.npmjs.org/event-as-promise/-/event-as-promise-1.0.3.tgz",
       "integrity": "sha512-y3mOpfy6wRemQGFXaAsbekG05d72/IK5sxQHNo/KGiYVYRtG0zER+fO2AAkqsL1KLTNqY7Da+GJWjzx0SHgIxg=="
     },
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
+    },
     "execa": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
         "p-finally": "^1.0.0",
@@ -864,16 +2167,186 @@
         "strip-eof": "^1.0.0"
       }
     },
-    "external-editor": {
-      "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-glob": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        }
+      }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fbjs": {
       "version": "0.8.17",
@@ -889,6 +2362,12 @@
         "ua-parser-js": "^0.7.18"
       }
     },
+    "figgy-pudding": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+      "dev": true
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -896,6 +2375,29 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "find-up": {
@@ -907,15 +2409,88 @@
         "locate-path": "^2.0.0"
       }
     },
+    "flush-write-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -938,29 +2513,13 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
         "wide-align": "^1.1.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
       }
+    },
+    "genfun": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+      "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -997,6 +2556,16 @@
             "map-obj": "^1.0.0"
           }
         },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
         "indent-string": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -1004,6 +2573,19 @@
           "dev": true,
           "requires": {
             "repeating": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "map-obj": {
@@ -1028,1333 +2610,6 @@
             "read-pkg-up": "^1.0.1",
             "redent": "^1.0.0",
             "trim-newlines": "^1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        }
-      }
-    },
-    "get-port": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
-    },
-    "git-raw-commits": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
-      "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
-      "dev": true,
-      "requires": {
-        "dargs": "^4.0.1",
-        "lodash.template": "^4.0.2",
-        "meow": "^4.0.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0"
-      }
-    },
-    "git-remote-origin-url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-      "dev": true,
-      "requires": {
-        "gitconfiglocal": "^1.0.0",
-        "pify": "^2.3.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
-    },
-    "git-semver-tags": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
-      "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
-      "dev": true,
-      "requires": {
-        "meow": "^4.0.0",
-        "semver": "^5.5.0"
-      }
-    },
-    "gitconfiglocal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-      "dev": true,
-      "requires": {
-        "ini": "^1.3.2"
-      }
-    },
-    "glamor": {
-      "version": "2.20.40",
-      "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
-      "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
-      "requires": {
-        "fbjs": "^0.8.12",
-        "inline-style-prefixer": "^3.0.6",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.5.10",
-        "through": "^2.3.8"
-      }
-    },
-    "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "globby": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
-    },
-    "got": {
-      "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "dev": true,
-      "requires": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
-    },
-    "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
-      "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        }
-      }
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
-    },
-    "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-      "dev": true
-    },
-    "hyphenate-style-name": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-      "dev": true
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
-    },
-    "inline-style-prefixer": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
-      "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
-      "requires": {
-        "bowser": "^1.7.3",
-        "css-in-js-utils": "^2.0.0"
-      }
-    },
-    "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "optional": true
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
-    },
-    "is-ci": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz",
-      "integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
-      "dev": true,
-      "requires": {
-        "ci-info": "^1.3.0"
-      }
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-      "dev": true
-    },
-    "is-text-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-      "dev": true,
-      "requires": {
-        "text-extensions": "^1.0.0"
-      }
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
-    "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "dev": true
-    },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
-      "optional": true
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
-    "lerna": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-2.11.0.tgz",
-      "integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
-      "dev": true,
-      "requires": {
-        "async": "^1.5.0",
-        "chalk": "^2.1.0",
-        "cmd-shim": "^2.0.2",
-        "columnify": "^1.5.4",
-        "command-join": "^2.0.0",
-        "conventional-changelog-cli": "^1.3.13",
-        "conventional-recommended-bump": "^1.2.1",
-        "dedent": "^0.7.0",
-        "execa": "^0.8.0",
-        "find-up": "^2.1.0",
-        "fs-extra": "^4.0.1",
-        "get-port": "^3.2.0",
-        "glob": "^7.1.2",
-        "glob-parent": "^3.1.0",
-        "globby": "^6.1.0",
-        "graceful-fs": "^4.1.11",
-        "hosted-git-info": "^2.5.0",
-        "inquirer": "^3.2.2",
-        "is-ci": "^1.0.10",
-        "load-json-file": "^4.0.0",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "npmlog": "^4.1.2",
-        "p-finally": "^1.0.0",
-        "package-json": "^4.0.1",
-        "path-exists": "^3.0.0",
-        "read-cmd-shim": "^1.0.1",
-        "read-pkg": "^3.0.0",
-        "rimraf": "^2.6.1",
-        "safe-buffer": "^5.1.1",
-        "semver": "^5.4.1",
-        "signal-exit": "^3.0.2",
-        "slash": "^1.0.0",
-        "strong-log-transformer": "^1.0.6",
-        "temp-write": "^3.3.0",
-        "write-file-atomic": "^2.3.0",
-        "write-json-file": "^2.2.0",
-        "write-pkg": "^3.1.0",
-        "yargs": "^8.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
-          },
-          "dependencies": {
-            "load-json-file": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "strip-bom": "^3.0.0"
-              }
-            },
-            "read-pkg": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-              "dev": true,
-              "requires": {
-                "load-json-file": "^2.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^2.0.0"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "yargs": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
-      }
-    },
-    "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
-      "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      }
-    },
-    "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
-    },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
-    },
-    "lodash.template": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "~3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "~3.0.0"
-      }
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
-      "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
-      }
-    },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      }
-    },
-    "map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-      "dev": true
-    },
-    "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^1.0.0"
-      }
-    },
-    "memoize-one": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.2.tgz",
-      "integrity": "sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg=="
-    },
-    "meow": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-      "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-      "dev": true,
-      "requires": {
-        "camelcase-keys": "^4.0.0",
-        "decamelize-keys": "^1.0.0",
-        "loud-rejection": "^1.0.0",
-        "minimist": "^1.1.3",
-        "minimist-options": "^3.0.1",
-        "normalize-package-data": "^2.3.4",
-        "read-pkg-up": "^3.0.0",
-        "redent": "^2.0.0",
-        "trim-newlines": "^2.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "read-pkg-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
-          }
-        }
-      }
-    },
-    "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "minimist-options": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-      "dev": true,
-      "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
-      }
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
-    },
-    "modify-values": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-      "dev": true
-    },
-    "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
-      "dev": true
-    },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
-    "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
-      "requires": {
-        "path-key": "^2.0.0"
-      }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^1.0.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "dev": true,
-      "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        }
-      }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
-      "requires": {
-        "p-try": "^1.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
-      "requires": {
-        "p-limit": "^1.1.0"
-      }
-    },
-    "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-      "dev": true
-    },
-    "package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-      "dev": true,
-      "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
-      }
-    },
-    "parse-github-repo-url": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-      "dev": true
-    },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      }
-    },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
-    },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      }
-    },
-    "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
-    },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
-    "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-      "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true
-    },
-    "quick-lru": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-      "dev": true
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
-    "read-cmd-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
-      "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2"
-      }
-    },
-    "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
           }
         },
         "parse-json": {
@@ -2403,6 +2658,26 @@
             "path-type": "^1.0.0"
           }
         },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "redent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+          "dev": true,
+          "requires": {
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
+          }
+        },
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -2411,7 +2686,2214 @@
           "requires": {
             "is-utf8": "^0.2.0"
           }
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+          "dev": true
         }
+      }
+    },
+    "get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "git-raw-commits": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
+      "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
+      "dev": true,
+      "requires": {
+        "dargs": "^4.0.1",
+        "lodash.template": "^4.0.2",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "git-remote-origin-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+      "dev": true,
+      "requires": {
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "git-semver-tags": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz",
+      "integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
+      "dev": true,
+      "requires": {
+        "meow": "^4.0.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "git-up": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
+      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "parse-url": "^5.0.0"
+      }
+    },
+    "git-url-parse": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
+      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "dev": true,
+      "requires": {
+        "git-up": "^4.0.0"
+      }
+    },
+    "gitconfiglocal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.2"
+      }
+    },
+    "glamor": {
+      "version": "2.20.40",
+      "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
+      "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
+      "requires": {
+        "fbjs": "^0.8.12",
+        "inline-style-prefixer": "^3.0.6",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.5.10",
+        "through": "^2.3.8"
+      }
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
+    "globby": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+      "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "dir-glob": "2.0.0",
+        "fast-glob": "^2.0.2",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "dev": true,
+      "requires": {
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+      "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "dev": true,
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
+    "hyphenate-style-name": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
+      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
+    "import-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "init-package-json": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+      "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.1",
+        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "promzard": "^0.3.0",
+        "read": "~1.0.1",
+        "read-package-json": "1 || 2",
+        "semver": "2.x || 3.x || 4 || 5",
+        "validate-npm-package-license": "^3.0.1",
+        "validate-npm-package-name": "^3.0.0"
+      }
+    },
+    "inline-style-prefixer": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
+      "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
+      "requires": {
+        "bowser": "^1.7.3",
+        "css-in-js-utils": "^2.0.0"
+      }
+    },
+    "inquirer": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-ci": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^1.5.0"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.0"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-ssh": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
+      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "dev": true,
+      "requires": {
+        "protocols": "^1.1.0"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-text-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+      "dev": true,
+      "requires": {
+        "text-extensions": "^2.0.0"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
+    },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
+    "lerna": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.14.1.tgz",
+      "integrity": "sha512-lQxmGeEECjOMI3pRh2+I6jazoEWhEfvZNIs7XaX71op33AVwyjlY/nQ1GJGrPhxYBuQnlPgH0vH/nC/lcLaVkw==",
+      "dev": true,
+      "requires": {
+        "@lerna/add": "3.14.0",
+        "@lerna/bootstrap": "3.14.0",
+        "@lerna/changed": "3.14.1",
+        "@lerna/clean": "3.14.0",
+        "@lerna/cli": "3.13.0",
+        "@lerna/create": "3.14.0",
+        "@lerna/diff": "3.14.0",
+        "@lerna/exec": "3.14.0",
+        "@lerna/import": "3.14.0",
+        "@lerna/init": "3.14.0",
+        "@lerna/link": "3.14.0",
+        "@lerna/list": "3.14.0",
+        "@lerna/publish": "3.14.1",
+        "@lerna/run": "3.14.0",
+        "@lerna/version": "3.14.1",
+        "import-local": "^1.0.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "libnpmaccess": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.1.tgz",
+      "integrity": "sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "get-stream": "^4.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.8.0"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        }
+      }
+    },
+    "libnpmpublish": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.1.tgz",
+      "integrity": "sha512-nefbvJd/wY38zdt+b9SHL6171vqBrMtZ56Gsgfd0duEKb/pB8rDT4/ObUQLrHz1tOfht1flt2zM+UGaemzAG5g==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "normalize-package-data": "^2.4.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.8.0",
+        "semver": "^5.5.1",
+        "ssri": "^6.0.1"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        }
+      }
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0"
+      }
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "macos-release": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
+      "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==",
+      "dev": true
+    },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      }
+    },
+    "make-fetch-happen": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz",
+      "integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
+      "dev": true,
+      "requires": {
+        "agentkeepalive": "^3.4.1",
+        "cacache": "^11.0.1",
+        "http-cache-semantics": "^3.8.1",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "lru-cache": "^4.1.2",
+        "mississippi": "^3.0.0",
+        "node-fetch-npm": "^2.0.2",
+        "promise-retry": "^1.1.1",
+        "socks-proxy-agent": "^4.0.0",
+        "ssri": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        }
+      }
+    },
+    "memoize-one": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
+      "integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
+    },
+    "meow": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+      "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist": "^1.1.3",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0"
+      }
+    },
+    "merge2": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+      "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.40.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "mississippi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "modify-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "dev": true
+    },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "multimatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "dev": true,
+      "requires": {
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "neo-async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node-fetch-npm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+      "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "json-parse-better-errors": "^1.0.0",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node-gyp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz",
+      "integrity": "sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^4.4.8",
+        "which": "1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-url": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+      "dev": true
+    },
+    "npm-bundled": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+      "dev": true
+    },
+    "npm-lifecycle": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.1.1.tgz",
+      "integrity": "sha512-+Vg6I60Z75V/09pdcH5iUo/99Q/vop35PaI99elvxk56azSVVsdsSsS/sXqKDNwbRRNN1qSxkcO45ZOu0yOWew==",
+      "dev": true,
+      "requires": {
+        "byline": "^5.0.0",
+        "graceful-fs": "^4.1.15",
+        "node-gyp": "^4.0.0",
+        "resolve-from": "^4.0.0",
+        "slide": "^1.1.6",
+        "uid-number": "0.0.6",
+        "umask": "^1.1.0",
+        "which": "^1.3.1"
+      }
+    },
+    "npm-package-arg": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
+      "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.6.0",
+        "osenv": "^0.1.5",
+        "semver": "^5.5.0",
+        "validate-npm-package-name": "^3.0.0"
+      }
+    },
+    "npm-packlist": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+      "dev": true,
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
+      }
+    },
+    "npm-pick-manifest": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz",
+      "integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "npm-package-arg": "^6.0.0",
+        "semver": "^5.4.1"
+      }
+    },
+    "npm-registry-fetch": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.9.0.tgz",
+      "integrity": "sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.3.4",
+        "bluebird": "^3.5.1",
+        "figgy-pudding": "^3.4.1",
+        "lru-cache": "^4.1.3",
+        "make-fetch-happen": "^4.0.1",
+        "npm-package-arg": "^6.1.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        }
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
+    "os-name": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+      "dev": true,
+      "requires": {
+        "macos-release": "^2.2.0",
+        "windows-release": "^3.1.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "p-map-series": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
+      "integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
+      "dev": true,
+      "requires": {
+        "p-reduce": "^1.0.0"
+      }
+    },
+    "p-pipe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
+      "integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k=",
+      "dev": true
+    },
+    "p-queue": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-4.0.0.tgz",
+      "integrity": "sha512-3cRXXn3/O0o3+eVmUroJPSj/esxoEFIm0ZOno/T+NzG/VZgPOqQ8WKmlNqubSEpZmCIngEy34unkHGg83ZIBmg==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^3.1.0"
+      }
+    },
+    "p-reduce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+      "dev": true
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "p-waterfall": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-waterfall/-/p-waterfall-1.0.0.tgz",
+      "integrity": "sha1-ftlLPOszMngjU69qrhGqn8I1uwA=",
+      "dev": true,
+      "requires": {
+        "p-reduce": "^1.0.0"
+      }
+    },
+    "pacote": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.0.tgz",
+      "integrity": "sha512-aUplXozRbzhaJO48FaaeClmN+2Mwt741MC6M3bevIGZwdCaP7frXzbUOfOWa91FPHoLITzG0hYaKY363lxO3bg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.3",
+        "cacache": "^11.3.2",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.1.0",
+        "glob": "^7.1.3",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^4.0.1",
+        "minimatch": "^3.0.4",
+        "minipass": "^2.3.5",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "normalize-package-data": "^2.4.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "^1.1.12",
+        "npm-pick-manifest": "^2.2.3",
+        "npm-registry-fetch": "^3.8.0",
+        "osenv": "^0.1.5",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^1.1.1",
+        "protoduck": "^5.0.1",
+        "rimraf": "^2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.6.0",
+        "ssri": "^6.0.1",
+        "tar": "^4.4.8",
+        "unique-filename": "^1.1.1",
+        "which": "^1.3.1"
+      }
+    },
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "dev": true,
+      "requires": {
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      }
+    },
+    "parse-github-repo-url": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
+      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
+    "parse-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
+      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0"
+      }
+    },
+    "parse-url": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
+      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "normalize-url": "^3.3.0",
+        "parse-path": "^4.0.0",
+        "protocols": "^1.4.0"
+      }
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
+    "promise-retry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+      "dev": true,
+      "requires": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      }
+    },
+    "promzard": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+      "dev": true,
+      "requires": {
+        "read": "1"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "requires": {
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
+    },
+    "protocols": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
+      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+      "dev": true
+    },
+    "protoduck": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+      "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
+      "dev": true,
+      "requires": {
+        "genfun": "^5.0.0"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
+      "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
+    "read-cmd-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+      "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "read-package-json": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
+      "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
+        "json-parse-better-errors": "^1.0.1",
+        "normalize-package-data": "^2.0.0",
+        "slash": "^1.0.0"
+      }
+    },
+    "read-package-tree": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.2.tgz",
+      "integrity": "sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "once": "^1.3.0",
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0"
+      }
+    },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^3.0.0"
       }
     },
     "readable-stream": {
@@ -2429,6 +4911,18 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "readdir-scoped-modules": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+      "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
+      }
+    },
     "redent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -2440,35 +4934,31 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
-    "registry-auth-token": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
-    "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "requires": {
-        "rc": "^1.0.1"
-      }
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -2477,6 +4967,34 @@
       "dev": true,
       "requires": {
         "is-finite": "^1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "require-directory": {
@@ -2491,6 +5009,44 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "resolve": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -2501,23 +5057,25 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.1"
-      }
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+      "dev": true
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
     },
     "run-async": {
@@ -2529,19 +5087,22 @@
         "is-promise": "^2.1.0"
       }
     },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "rx-lite": "*"
+        "aproba": "^1.1.1"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -2550,15 +5111,24 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "dev": true
     },
     "set-blocking": {
@@ -2566,6 +5136,29 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -2599,6 +5192,145 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
+    "smart-buffer": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+      "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "socks": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
+      "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "4.0.2"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "~4.2.1",
+        "socks": "~2.3.2"
+      }
+    },
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -2609,18 +5341,34 @@
       }
     },
     "source-map": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "amdefine": ">=0.0.4"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
     "spdx-correct": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -2628,9 +5376,9 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
     "spdx-expression-parse": {
@@ -2644,9 +5392,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
     "split": {
@@ -2658,6 +5406,15 @@
         "through": "2"
       }
     },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
@@ -2667,31 +5424,84 @@
         "through2": "^2.0.2"
       }
     },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "ssri": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1"
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "is-descriptor": "^0.1.0"
           }
         }
+      }
+    },
+    "stream-each": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -2730,31 +5540,39 @@
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
-    },
     "strong-log-transformer": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz",
-      "integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
+      "integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
       "dev": true,
       "requires": {
-        "byline": "^5.0.0",
         "duplexer": "^0.1.1",
-        "minimist": "^0.1.0",
-        "moment": "^2.6.0",
+        "minimist": "^1.2.0",
         "through": "^2.3.4"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.1.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-          "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
-          "dev": true
-        }
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "tar": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
       }
     },
     "temp-dir": {
@@ -2775,30 +5593,12 @@
         "pify": "^3.0.0",
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true
-        }
-      }
-    },
-    "tempfile": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
-      "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "^1.0.0",
-        "uuid": "^2.0.1"
       }
     },
     "text-extensions": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-      "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
+      "integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
       "dev": true
     },
     "through": {
@@ -2807,20 +5607,14 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
+        "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
-    },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -2829,6 +5623,75 @@
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
+      }
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
       }
     },
     "trim-newlines": {
@@ -2843,6 +5706,27 @@
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -2855,45 +5739,98 @@
       "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
     },
     "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.15.tgz",
+      "integrity": "sha512-fe7aYFotptIddkwcm6YuA0HmknBZ52ZzOsUxZEdhhkSsz7RfjHDX2QDxwKTiv4JQ5t5NhfmpgAK+J7LiDhKSqg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "commander": "~2.20.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+        }
+      }
+    },
+    "uid-number": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+      "dev": true
+    },
+    "umask": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+      "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0"
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
     },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+    "unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
+      "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "universal-user-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
+      "integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
+      "dev": true,
+      "requires": {
+        "os-name": "^3.0.0"
+      }
     },
     "universalify": {
       "version": "0.1.2",
@@ -2901,20 +5838,72 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
-    "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true
-    },
-    "url-parse-lax": {
+    "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
       }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+      "dev": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -2923,9 +5912,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -2938,6 +5927,26 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "dev": true,
+      "requires": {
+        "builtins": "^1.0.3"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -2947,10 +5956,27 @@
         "defaults": "^1.0.3"
       }
     },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    },
+    "whatwg-url": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+      "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
     },
     "which": {
       "version": "1.3.1",
@@ -2976,12 +6002,14 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+    "windows-release": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "execa": "^1.0.0"
+      }
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -2997,28 +6025,6 @@
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
       }
     },
     "wrappy": {
@@ -3028,9 +6034,9 @@
       "dev": true
     },
     "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -3050,14 +6056,6 @@
         "pify": "^3.0.0",
         "sort-keys": "^2.0.0",
         "write-file-atomic": "^2.0.0"
-      },
-      "dependencies": {
-        "detect-indent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-          "dev": true
-        }
       }
     },
     "write-pkg": {
@@ -3077,16 +6075,130 @@
       "dev": true
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "dev": true
+    },
+    "yargs": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^3.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^11.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,16 +34,16 @@
   },
   "homepage": "https://github.com/compulim/react-say#readme",
   "dependencies": {
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.4.5",
     "classnames": "^2.2.6",
     "event-as-promise": "^1.0.3",
     "glamor": "^2.20.40",
-    "memoize-one": "^4.0.0"
+    "memoize-one": "^5.0.4"
   },
   "peerDependencies": {
     "react": "^16.4.1"
   },
   "devDependencies": {
-    "lerna": "^2.11.0"
+    "lerna": "^3.14.1"
   }
 }

--- a/packages/component/.babelrc
+++ b/packages/component/.babelrc
@@ -1,13 +1,13 @@
 {
   "plugins": [
-    "transform-object-rest-spread",
-    "transform-runtime"
+    "@babel/plugin-proposal-object-rest-spread",
+    "@babel/plugin-transform-runtime"
   ],
   "presets": [
-    ["env", {
+    ["@babel/preset-env", {
       "forceAllTransforms": true,
       "modules": "commonjs"
     }],
-    "react"
+    "@babel/preset-react"
   ]
 }

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -5580,7 +5580,8 @@
 		"has-resolved": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-resolved/-/has-resolved-1.1.0.tgz",
-			"integrity": "sha512-/8aGbzLptuQ+jVgXEhKp2Sd2bZm9ZabJUDUA/2FsbPif0ifCtpoP4HdJjWmeItHttxFTfR1q2tNI0RGeZ7vmxA=="
+			"integrity": "sha512-/8aGbzLptuQ+jVgXEhKp2Sd2bZm9ZabJUDUA/2FsbPif0ifCtpoP4HdJjWmeItHttxFTfR1q2tNI0RGeZ7vmxA==",
+			"dev": true
 		},
 		"has-symbols": {
 			"version": "1.0.0",

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -4,76 +4,577 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@babel/code-frame": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
-			"integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+		"@babel/cli": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.4.4.tgz",
+			"integrity": "sha512-XGr5YjQSjgTa6OzQZY57FAJsdeVSAKR/u/KA5exWIz66IKtv/zXtHy+fIZcMry/EgYegwuHE7vzGnrFhjdIAsQ==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.51"
-			}
-		},
-		"@babel/generator": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
-			"integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
-			"dev": true,
-			"requires": {
-				"@babel/types": "7.0.0-beta.51",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.17.5",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"chokidar": "^2.0.4",
+				"commander": "^2.8.1",
+				"convert-source-map": "^1.1.0",
+				"fs-readdir-recursive": "^1.1.0",
+				"glob": "^7.0.0",
+				"lodash": "^4.17.11",
+				"mkdirp": "^0.5.1",
+				"output-file-sync": "^2.0.0",
+				"slash": "^2.0.0",
+				"source-map": "^0.5.0"
 			},
 			"dependencies": {
-				"jsesc": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"remove-trailing-separator": "^1.0.1"
+							}
+						}
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true,
+					"optional": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true,
+					"optional": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"chokidar": {
+					"version": "2.1.6",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+					"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"anymatch": "^2.0.0",
+						"async-each": "^1.0.1",
+						"braces": "^2.3.2",
+						"fsevents": "^1.2.7",
+						"glob-parent": "^3.1.0",
+						"inherits": "^2.0.3",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^4.0.0",
+						"normalize-path": "^3.0.0",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.2.1",
+						"upath": "^1.1.1"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"optional": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"optional": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-extglob": "^2.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+					"dev": true,
+					"optional": true
+				},
+				"is-glob": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true,
+					"optional": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true,
+					"optional": true
+				},
+				"output-file-sync": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-2.0.1.tgz",
+					"integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"is-plain-obj": "^1.1.0",
+						"mkdirp": "^0.5.1"
+					}
+				},
+				"readdirp": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"micromatch": "^3.1.10",
+						"readable-stream": "^2.0.2"
+					}
+				},
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
 					"dev": true
 				}
 			}
 		},
-		"@babel/helper-function-name": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
-			"integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+		"@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.51",
-				"@babel/template": "7.0.0-beta.51",
-				"@babel/types": "7.0.0-beta.51"
+				"@babel/highlight": "^7.0.0"
 			}
 		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
-			"integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+		"@babel/core": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
+			"integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.51"
-			}
-		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
-			"integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
-			"dev": true,
-			"requires": {
-				"@babel/types": "7.0.0-beta.51"
-			}
-		},
-		"@babel/highlight": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
-			"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.4",
+				"@babel/helpers": "^7.4.4",
+				"@babel/parser": "^7.4.5",
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.5",
+				"@babel/types": "^7.4.4",
+				"convert-source-map": "^1.1.0",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.11",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -84,9 +585,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
@@ -94,10 +595,336 @@
 						"supports-color": "^5.3.0"
 					}
 				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"jsesc": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+					"dev": true
+				},
+				"json5": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"resolve": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+					"integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+			"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.4",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.11",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-builder-react-jsx": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
+			"integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.3.0",
+				"esutils": "^2.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-call-delegate": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+			"integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"jsesc": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
 				},
 				"supports-color": {
@@ -108,73 +935,7 @@
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
-				}
-			}
-		},
-		"@babel/parser": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
-			"integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
-			"dev": true
-		},
-		"@babel/template": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
-			"integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "7.0.0-beta.51",
-				"@babel/parser": "7.0.0-beta.51",
-				"@babel/types": "7.0.0-beta.51",
-				"lodash": "^4.17.5"
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
-			"integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "7.0.0-beta.51",
-				"@babel/generator": "7.0.0-beta.51",
-				"@babel/helper-function-name": "7.0.0-beta.51",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.51",
-				"@babel/parser": "7.0.0-beta.51",
-				"@babel/types": "7.0.0-beta.51",
-				"debug": "^3.1.0",
-				"globals": "^11.1.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.17.5"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
 				},
-				"globals": {
-					"version": "11.7.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-					"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
-					"dev": true
-				}
-			}
-		},
-		"@babel/types": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
-			"integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
-			"dev": true,
-			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.5",
-				"to-fast-properties": "^2.0.0"
-			},
-			"dependencies": {
 				"to-fast-properties": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -183,6 +944,2739 @@
 				}
 			}
 		},
+		"@babel/helper-define-map": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
+			"integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/types": "^7.4.4",
+				"lodash": "^4.17.11"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+			"dev": true,
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"jsesc": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+			"integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.4"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+			"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+			"integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/template": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"lodash": "^4.17.11"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"dev": true
+		},
+		"@babel/helper-regex": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+			"integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.11"
+			}
+		},
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-wrap-function": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"jsesc": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
+			"integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.0.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"jsesc": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.4"
+			}
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.2.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"jsesc": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+			"integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"jsesc": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+			"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+			"dev": true
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0",
+				"@babel/plugin-syntax-async-generators": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-json-strings": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+			"integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-json-strings": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
+			"integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+			"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.5.4"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				},
+				"regexpu-core": {
+					"version": "4.5.4",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+					"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.0.2",
+						"regjsgen": "^0.5.0",
+						"regjsparser": "^0.6.0",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.1.0"
+					}
+				},
+				"regjsgen": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+					"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+					"dev": true
+				},
+				"regjsparser": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+					"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+					"dev": true,
+					"requires": {
+						"jsesc": "~0.5.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+			"integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+			"integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-jsx": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+			"integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-arrow-functions": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+			"integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
+			"integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0"
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+			"integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
+			"integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"lodash": "^4.17.11"
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
+			"integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-define-map": "^7.4.4",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.4.4",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-computed-properties": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+			"integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
+			"integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.5.4"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				},
+				"regexpu-core": {
+					"version": "4.5.4",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+					"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.0.2",
+						"regjsgen": "^0.5.0",
+						"regjsparser": "^0.6.0",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.1.0"
+					}
+				},
+				"regjsgen": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+					"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+					"dev": true
+				},
+				"regjsparser": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+					"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+					"dev": true,
+					"requires": {
+						"jsesc": "~0.5.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
+			"integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+			"integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+			"integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+			"integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+			"integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+			"integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
+			"integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
+			"integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.4.4",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0"
+			}
+		},
+		"@babel/plugin-transform-modules-systemjs": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
+			"integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.4.4",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-modules-umd": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+			"integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
+			"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+			"dev": true,
+			"requires": {
+				"regexp-tree": "^0.1.6"
+			}
+		},
+		"@babel/plugin-transform-new-target": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+			"integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+			"integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0"
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+			"integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-call-delegate": "^7.4.4",
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+			"integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-react-display-name": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+			"integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-react-jsx": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
+			"integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-builder-react-jsx": "^7.3.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-react-jsx-self": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
+			"integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-react-jsx-source": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
+			"integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+			"integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+			"dev": true,
+			"requires": {
+				"regenerator-transform": "^0.14.0"
+			},
+			"dependencies": {
+				"regenerator-transform": {
+					"version": "0.14.0",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
+					"integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
+					"dev": true,
+					"requires": {
+						"private": "^0.1.6"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+			"integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-runtime": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz",
+			"integrity": "sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"resolve": "^1.8.1",
+				"semver": "^5.5.1"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+					"integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+			"integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+			"integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+			"integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+			"integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+			"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.5.4"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				},
+				"regexpu-core": {
+					"version": "4.5.4",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+					"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.0.2",
+						"regjsgen": "^0.5.0",
+						"regjsparser": "^0.6.0",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.1.0"
+					}
+				},
+				"regjsgen": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+					"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+					"dev": true
+				},
+				"regjsparser": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+					"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+					"dev": true,
+					"requires": {
+						"jsesc": "~0.5.0"
+					}
+				}
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.5.tgz",
+			"integrity": "sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+				"@babel/plugin-proposal-json-strings": "^7.2.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-syntax-async-generators": "^7.2.0",
+				"@babel/plugin-syntax-json-strings": "^7.2.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+				"@babel/plugin-transform-arrow-functions": "^7.2.0",
+				"@babel/plugin-transform-async-to-generator": "^7.4.4",
+				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+				"@babel/plugin-transform-block-scoping": "^7.4.4",
+				"@babel/plugin-transform-classes": "^7.4.4",
+				"@babel/plugin-transform-computed-properties": "^7.2.0",
+				"@babel/plugin-transform-destructuring": "^7.4.4",
+				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/plugin-transform-duplicate-keys": "^7.2.0",
+				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+				"@babel/plugin-transform-for-of": "^7.4.4",
+				"@babel/plugin-transform-function-name": "^7.4.4",
+				"@babel/plugin-transform-literals": "^7.2.0",
+				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
+				"@babel/plugin-transform-modules-amd": "^7.2.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.4.4",
+				"@babel/plugin-transform-modules-systemjs": "^7.4.4",
+				"@babel/plugin-transform-modules-umd": "^7.2.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+				"@babel/plugin-transform-new-target": "^7.4.4",
+				"@babel/plugin-transform-object-super": "^7.2.0",
+				"@babel/plugin-transform-parameters": "^7.4.4",
+				"@babel/plugin-transform-property-literals": "^7.2.0",
+				"@babel/plugin-transform-regenerator": "^7.4.5",
+				"@babel/plugin-transform-reserved-words": "^7.2.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
+				"@babel/plugin-transform-spread": "^7.2.0",
+				"@babel/plugin-transform-sticky-regex": "^7.2.0",
+				"@babel/plugin-transform-template-literals": "^7.4.4",
+				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
+				"@babel/plugin-transform-unicode-regex": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"browserslist": "^4.6.0",
+				"core-js-compat": "^3.1.1",
+				"invariant": "^2.2.2",
+				"js-levenshtein": "^1.1.3",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"browserslist": {
+					"version": "4.6.1",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
+					"integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000971",
+						"electron-to-chromium": "^1.3.137",
+						"node-releases": "^1.1.21"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000971",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
+					"integrity": "sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.137",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+					"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==",
+					"dev": true
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/preset-react": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
+			"integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-transform-react-display-name": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/plugin-transform-react-jsx-self": "^7.0.0",
+				"@babel/plugin-transform-react-jsx-source": "^7.0.0"
+			}
+		},
+		"@babel/runtime": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+			"integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+			"requires": {
+				"regenerator-runtime": "^0.13.2"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+				}
+			}
+		},
+		"@babel/template": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.4.4",
+				"@babel/types": "^7.4.4"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+			"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.4",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/parser": "^7.4.5",
+				"@babel/types": "^7.4.4",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.11"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+			"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.11",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@cnakazawa/watch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+			"dev": true,
+			"requires": {
+				"exec-sh": "^0.3.2",
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
+		"@jest/console": {
+			"version": "24.7.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
+			"integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+			"dev": true,
+			"requires": {
+				"@jest/source-map": "^24.3.0",
+				"chalk": "^2.0.1",
+				"slash": "^2.0.0"
+			}
+		},
+		"@jest/core": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
+			"integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.7.1",
+				"@jest/reporters": "^24.8.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-changed-files": "^24.8.0",
+				"jest-config": "^24.8.0",
+				"jest-haste-map": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve-dependencies": "^24.8.0",
+				"jest-runner": "^24.8.0",
+				"jest-runtime": "^24.8.0",
+				"jest-snapshot": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-validate": "^24.8.0",
+				"jest-watcher": "^24.8.0",
+				"micromatch": "^3.1.10",
+				"p-each-series": "^1.0.0",
+				"pirates": "^4.0.1",
+				"realpath-native": "^1.1.0",
+				"rimraf": "^2.5.4",
+				"strip-ansi": "^5.0.0"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"dev": true
+				}
+			}
+		},
+		"@jest/environment": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
+			"integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
+			"dev": true,
+			"requires": {
+				"@jest/fake-timers": "^24.8.0",
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"jest-mock": "^24.8.0"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
+			"integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-mock": "^24.8.0"
+			}
+		},
+		"@jest/reporters": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
+			"integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.8.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.2",
+				"istanbul-lib-coverage": "^2.0.2",
+				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-report": "^2.0.4",
+				"istanbul-lib-source-maps": "^3.0.1",
+				"istanbul-reports": "^2.1.1",
+				"jest-haste-map": "^24.8.0",
+				"jest-resolve": "^24.8.0",
+				"jest-runtime": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-worker": "^24.6.0",
+				"node-notifier": "^5.2.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0",
+				"string-length": "^2.0.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"@jest/source-map": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.1.15",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"@jest/test-result": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
+			"integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.7.1",
+				"@jest/types": "^24.8.0",
+				"@types/istanbul-lib-coverage": "^2.0.0"
+			}
+		},
+		"@jest/test-sequencer": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
+			"integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^24.8.0",
+				"jest-haste-map": "^24.8.0",
+				"jest-runner": "^24.8.0",
+				"jest-runtime": "^24.8.0"
+			}
+		},
+		"@jest/transform": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
+			"integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.8.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"jest-haste-map": "^24.8.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-util": "^24.8.0",
+				"micromatch": "^3.1.10",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.1",
+				"write-file-atomic": "2.4.1"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"@jest/types": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
+			"integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^1.1.1",
+				"@types/yargs": "^12.0.9"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
+			"integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+			"integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+			"integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
+		"@types/istanbul-lib-coverage": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+			"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+			"dev": true
+		},
+		"@types/istanbul-lib-report": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+			"integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"@types/istanbul-reports": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+			"integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "*",
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"@types/stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+			"dev": true
+		},
+		"@types/yargs": {
+			"version": "12.0.12",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
+			"integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
+			"dev": true
+		},
 		"abab": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -190,105 +3684,73 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
-			"integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
 			"dev": true
 		},
 		"acorn-globals": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.0.0"
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
-		"ajv": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-			"dev": true,
-			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
-			}
-		},
-		"align-text": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
-			}
-		},
-		"amdefine": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+		"acorn-walk": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
 			"dev": true
 		},
+		"ajv": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
 		"ansi-escapes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
 			"dev": true
 		},
 		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 			"dev": true
 		},
 		"ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"dev": true
-		},
-		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
-			}
-		},
-		"append-transform": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "^2.0.0"
-			}
-		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"requires": {
-				"sprintf-js": "~1.0.2"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"arr-diff": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"dev": true,
-			"requires": {
-				"arr-flatten": "^1.0.1"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
@@ -309,15 +3771,9 @@
 			"dev": true
 		},
 		"array-unique": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-			"dev": true
-		},
-		"arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
 		},
 		"asap": {
@@ -351,15 +3807,6 @@
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
-		},
-		"async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.10"
-			}
 		},
 		"async-each": {
 			"version": "1.0.1",
@@ -398,826 +3845,50 @@
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
 		},
-		"babel-cli": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
-			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
-			"dev": true,
-			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-polyfill": "^6.26.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"chokidar": "^1.6.1",
-				"commander": "^2.11.0",
-				"convert-source-map": "^1.5.0",
-				"fs-readdir-recursive": "^1.0.0",
-				"glob": "^7.1.2",
-				"lodash": "^4.17.4",
-				"output-file-sync": "^1.1.2",
-				"path-is-absolute": "^1.0.1",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.6",
-				"v8flags": "^2.1.1"
-			}
-		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
-			},
-			"dependencies": {
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
-			}
-		},
-		"babel-core": {
-			"version": "6.26.3",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.1",
-				"debug": "^2.6.9",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.8",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.7"
-			}
-		},
-		"babel-generator": {
-			"version": "6.26.1",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"dev": true,
-			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
-			}
-		},
-		"babel-helper-builder-binary-assignment-operator-visitor": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"dev": true,
-			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-builder-react-jsx": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
-			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"esutils": "^2.0.2"
-			}
-		},
-		"babel-helper-call-delegate": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"dev": true,
-			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-define-map": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-			"dev": true,
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-helper-explode-assignable-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"dev": true,
-			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-get-function-arity": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-hoist-variables": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-optimise-call-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-regex": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-helper-remap-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"dev": true,
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-replace-supers": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-			"dev": true,
-			"requires": {
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helpers": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
 		"babel-jest": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
-			"integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
+			"integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "^4.1.5",
-				"babel-preset-jest": "^22.4.4"
-			}
-		},
-		"babel-messages": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-check-es2015-constants": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"@types/babel__core": "^7.1.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"babel-preset-jest": "^24.6.0",
+				"chalk": "^2.4.2",
+				"slash": "^2.0.0"
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+			"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
-				"find-up": "^2.1.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"test-exclude": "^4.2.1"
+				"find-up": "^3.0.0",
+				"istanbul-lib-instrument": "^3.3.0",
+				"test-exclude": "^5.2.3"
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
-			"integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
-			"dev": true
-		},
-		"babel-plugin-syntax-async-functions": {
-			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-			"dev": true
-		},
-		"babel-plugin-syntax-exponentiation-operator": {
-			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-			"dev": true
-		},
-		"babel-plugin-syntax-flow": {
-			"version": "6.18.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
-			"dev": true
-		},
-		"babel-plugin-syntax-jsx": {
-			"version": "6.18.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-			"dev": true
-		},
-		"babel-plugin-syntax-object-rest-spread": {
-			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-			"dev": true
-		},
-		"babel-plugin-syntax-trailing-function-commas": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-			"dev": true
-		},
-		"babel-plugin-transform-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"version": "24.6.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+			"integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-arrow-functions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-block-scoped-functions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-block-scoping": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-plugin-transform-es2015-classes": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-			"dev": true,
-			"requires": {
-				"babel-helper-define-map": "^6.24.1",
-				"babel-helper-function-name": "^6.24.1",
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-computed-properties": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-destructuring": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-duplicate-keys": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-for-of": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"dev": true,
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-literals": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-amd": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-			"dev": true,
-			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-			"dev": true,
-			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-systemjs": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"dev": true,
-			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-umd": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"dev": true,
-			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-object-super": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"dev": true,
-			"requires": {
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-parameters": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"dev": true,
-			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-shorthand-properties": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-spread": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-sticky-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"dev": true,
-			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-template-literals": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-typeof-symbol": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-unicode-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"dev": true,
-			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
-			}
-		},
-		"babel-plugin-transform-exponentiation-operator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"dev": true,
-			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-flow-strip-types": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-			"dev": true,
-			"requires": {
-				"babel-plugin-syntax-flow": "^6.18.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-object-rest-spread": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-			"dev": true,
-			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-runtime": "^6.26.0"
-			}
-		},
-		"babel-plugin-transform-react-display-name": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
-			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
-			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
-			"dev": true,
-			"requires": {
-				"babel-helper-builder-react-jsx": "^6.24.1",
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx-self": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-			"dev": true,
-			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx-source": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
-			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-			"dev": true,
-			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-regenerator": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-			"dev": true,
-			"requires": {
-				"regenerator-transform": "^0.10.0"
-			}
-		},
-		"babel-plugin-transform-runtime": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
-			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-strict-mode": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-polyfill": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"regenerator-runtime": "^0.10.5"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.10.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-					"dev": true
-				}
-			}
-		},
-		"babel-preset-env": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-			"integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-			"dev": true,
-			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-				"babel-plugin-transform-async-to-generator": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-				"babel-plugin-transform-es2015-classes": "^6.23.0",
-				"babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-				"babel-plugin-transform-es2015-for-of": "^6.23.0",
-				"babel-plugin-transform-es2015-function-name": "^6.22.0",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-				"babel-plugin-transform-es2015-object-super": "^6.22.0",
-				"babel-plugin-transform-es2015-parameters": "^6.23.0",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-				"babel-plugin-transform-exponentiation-operator": "^6.22.0",
-				"babel-plugin-transform-regenerator": "^6.22.0",
-				"browserslist": "^3.2.6",
-				"invariant": "^2.2.2",
-				"semver": "^5.3.0"
-			}
-		},
-		"babel-preset-flow": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
-			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
-			"dev": true,
-			"requires": {
-				"babel-plugin-transform-flow-strip-types": "^6.22.0"
+				"@types/babel__traverse": "^7.0.6"
 			}
 		},
 		"babel-preset-jest": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
-			"integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
+			"version": "24.6.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+			"integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^22.4.4",
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"babel-plugin-jest-hoist": "^24.6.0"
 			}
-		},
-		"babel-preset-react": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
-			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
-			"dev": true,
-			"requires": {
-				"babel-plugin-syntax-jsx": "^6.3.13",
-				"babel-plugin-transform-react-display-name": "^6.23.0",
-				"babel-plugin-transform-react-jsx": "^6.24.1",
-				"babel-plugin-transform-react-jsx-self": "^6.22.0",
-				"babel-plugin-transform-react-jsx-source": "^6.22.0",
-				"babel-preset-flow": "^6.23.0"
-			}
-		},
-		"babel-register": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"dev": true,
-			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
-			}
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			}
-		},
-		"babel-template": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-traverse": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-types": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
-			}
-		},
-		"babylon": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -1291,7 +3962,6 @@
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -1319,20 +3989,38 @@
 			}
 		},
 		"braces": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"dev": true,
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"browser-process-hrtime": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
 			"dev": true
 		},
 		"browser-resolve": {
@@ -1342,16 +4030,14 @@
 			"dev": true,
 			"requires": {
 				"resolve": "1.1.7"
-			}
-		},
-		"browserslist": {
-			"version": "3.2.8",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-			"integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-			"dev": true,
-			"requires": {
-				"caniuse-lite": "^1.0.30000844",
-				"electron-to-chromium": "^1.3.47"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
+				}
 			}
 		},
 		"bser": {
@@ -1367,12 +4053,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
-		},
-		"builtin-modules": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
 		},
 		"cache-base": {
@@ -1393,31 +4073,24 @@
 			}
 		},
 		"callsites": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true
 		},
 		"camelcase": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-			"dev": true,
-			"optional": true
-		},
-		"caniuse-lite": {
-			"version": "1.0.30000883",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000883.tgz",
-			"integrity": "sha512-ovvb0uya4cKJct8Rj9Olstz0LaWmyJhCp3NawRG5fVigka8pEhIIwipF7zyYd2Q58UZb5YfIt52pVF444uj2kQ==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true
 		},
 		"capture-exit": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
-			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+			"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
 			"dev": true,
 			"requires": {
-				"rsvp": "^3.3.3"
+				"rsvp": "^4.8.4"
 			}
 		},
 		"caseless": {
@@ -1426,52 +4099,21 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
-		"center-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
-			}
-		},
 		"chalk": {
-			"version": "1.1.3",
-			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
-			}
-		},
-		"chokidar": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"anymatch": "^1.3.0",
-				"async-each": "^1.0.0",
-				"fsevents": "^1.0.0",
-				"glob-parent": "^2.0.0",
-				"inherits": "^2.0.1",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^2.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"ci-info": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.4.0.tgz",
-			"integrity": "sha512-Oqmw2pVfCl8sCL+1QgMywPfdxPJPkC51y4usw0iiE2S9qnEOAqXy8bwl1CpMpnoU39g4iKJTz6QZj+28FvOnjQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
 			"dev": true
 		},
 		"class-utils": {
@@ -1503,23 +4145,30 @@
 			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"cliui": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"center-align": "^0.1.1",
-				"right-align": "^0.1.1",
-				"wordwrap": "0.0.2"
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
 			},
 			"dependencies": {
-				"wordwrap": {
-					"version": "0.0.2",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
-					"optional": true
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -1561,9 +4210,9 @@
 			"dev": true
 		},
 		"combined-stream": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
@@ -1573,12 +4222,6 @@
 			"version": "2.17.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
 			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-			"dev": true
-		},
-		"compare-versions": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
-			"integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
 			"dev": true
 		},
 		"component-emitter": {
@@ -1605,10 +4248,53 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+		"core-js-compat": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.3.tgz",
+			"integrity": "sha512-EP018pVhgwsKHz3YoN1hTq49aRe+h017Kjz0NQz3nXV0cCRMvH3fLQl+vEPGr4r4J5sk4sU3tUC7U1aqTCeJeA==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.6.0",
+				"core-js-pure": "3.1.3",
+				"semver": "^6.1.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.6.1",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
+					"integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000971",
+						"electron-to-chromium": "^1.3.137",
+						"node-releases": "^1.1.21"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000971",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
+					"integrity": "sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.137",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+					"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"dev": true
+				}
+			}
+		},
+		"core-js-pure": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.3.tgz",
+			"integrity": "sha512-k3JWTrcQBKqjkjI0bkfXS0lbpWPxYuHWfMMjC1VDmzU4Q58IwSbuXSo99YO/hUHlw/EB4AlfA2PVxOGkrIq6dA==",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1617,12 +4303,14 @@
 			"dev": true
 		},
 		"cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.0.1",
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
@@ -1637,15 +4325,15 @@
 			}
 		},
 		"cssom": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-			"integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
-			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
+			"integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
 			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
@@ -1661,13 +4349,13 @@
 			}
 		},
 		"data-urls": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz",
-			"integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.0",
-				"whatwg-mimetype": "^2.1.0",
+				"whatwg-mimetype": "^2.2.0",
 				"whatwg-url": "^7.0.0"
 			},
 			"dependencies": {
@@ -1710,15 +4398,6 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
-		},
-		"default-require-extensions": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
-			"dev": true,
-			"requires": {
-				"strip-bom": "^3.0.0"
-			}
 		},
 		"define-properties": {
 			"version": "1.1.3",
@@ -1782,25 +4461,16 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
-		"detect-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"dev": true,
-			"requires": {
-				"repeating": "^2.0.0"
-			}
-		},
 		"detect-newline": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
 			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
 			"dev": true
 		},
-		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+		"diff-sequences": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+			"integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
 			"dev": true
 		},
 		"domexception": {
@@ -1817,17 +4487,10 @@
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
-		},
-		"electron-to-chromium": {
-			"version": "1.3.62",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
-			"integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg==",
-			"dev": true
 		},
 		"encoding": {
 			"version": "0.1.12",
@@ -1835,6 +4498,15 @@
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
 				"iconv-lite": "~0.4.13"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
 			}
 		},
 		"error-ex": {
@@ -1847,27 +4519,28 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.1.1",
+				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
 			}
 		},
 		"es-to-primitive": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.1",
+				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
+				"is-symbol": "^1.0.2"
 			}
 		},
 		"escape-string-regexp": {
@@ -1877,9 +4550,9 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
 			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
@@ -1889,12 +4562,6 @@
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-					"dev": true
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1905,9 +4572,9 @@
 			}
 		},
 		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
 			"dev": true
 		},
 		"estraverse": {
@@ -1928,22 +4595,19 @@
 			"integrity": "sha512-z/WIlyou7oTvXBjm5YYjfklr2d8gUWtx8b5GAcrIs1n1D35f7NIK0CrcYSXbY3VYikG9bUan+wScPyGXL/NH4A=="
 		},
 		"exec-sh": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-			"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
-			"dev": true,
-			"requires": {
-				"merge": "^1.2.0"
-			}
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+			"integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+			"dev": true
 		},
 		"execa": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
 				"is-stream": "^1.1.0",
 				"npm-run-path": "^2.0.0",
 				"p-finally": "^1.0.0",
@@ -1958,46 +4622,52 @@
 			"dev": true
 		},
 		"expand-brackets": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
-			}
-		},
-		"expand-range": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
-			"requires": {
-				"fill-range": "^2.1.0"
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"expect": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
-			"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
+			"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
 			"dev": true,
 			"requires": {
+				"@jest/types": "^24.8.0",
 				"ansi-styles": "^3.2.0",
-				"jest-diff": "^22.4.3",
-				"jest-get-type": "^22.4.3",
-				"jest-matcher-utils": "^22.4.3",
-				"jest-message-util": "^22.4.3",
-				"jest-regex-util": "^22.4.3"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				}
+				"jest-get-type": "^24.8.0",
+				"jest-matcher-utils": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-regex-util": "^24.3.0"
 			}
 		},
 		"extend": {
@@ -2028,12 +4698,74 @@
 			}
 		},
 		"extglob": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
 			}
 		},
 		"extsprintf": {
@@ -2043,9 +4775,9 @@
 			"dev": true
 		},
 		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 			"dev": true
 		},
 		"fast-json-stable-stringify": {
@@ -2090,53 +4822,36 @@
 				}
 			}
 		},
-		"filename-regex": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
-		},
-		"fileset": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
-			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-			"dev": true,
-			"requires": {
-				"glob": "^7.0.3",
-				"minimatch": "^3.0.3"
-			}
-		},
 		"fill-range": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"dev": true,
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^3.0.0",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
 			},
 			"dependencies": {
-				"isobject": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"isarray": "1.0.0"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
 		},
 		"find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "^3.0.0"
 			}
 		},
 		"for-in": {
@@ -2145,15 +4860,6 @@
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
 		},
-		"for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
-			"requires": {
-				"for-in": "^1.0.1"
-			}
-		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -2161,13 +4867,13 @@
 			"dev": true
 		},
 		"form-data": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
-				"combined-stream": "1.0.6",
+				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
 		},
@@ -2193,14 +4899,14 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "^2.12.1",
+				"node-pre-gyp": "^0.12.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2222,7 +4928,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2248,7 +4954,7 @@
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2278,16 +4984,16 @@
 					"optional": true
 				},
 				"debug": {
-					"version": "2.6.9",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2336,7 +5042,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2356,12 +5062,12 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore-walk": {
@@ -2426,17 +5132,17 @@
 					"optional": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2454,35 +5160,35 @@
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
+					"version": "2.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.3.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
+						"debug": "^4.1.0",
 						"iconv-lite": "^0.4.4",
 						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.12.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
 						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
+						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4"
@@ -2499,13 +5205,13 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.4.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2582,12 +5288,12 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -2617,16 +5323,16 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
+					"version": "5.1.2",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2644,7 +5350,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.7.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2697,17 +5403,17 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
+						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
 						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
 				},
@@ -2718,12 +5424,12 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
@@ -2733,7 +5439,7 @@
 					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2753,10 +5459,13 @@
 			"dev": true
 		},
 		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			}
 		},
 		"get-value": {
 			"version": "2.0.6",
@@ -2799,29 +5508,10 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
-			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
-			}
-		},
-		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"dev": true,
-			"requires": {
-				"is-glob": "^2.0.0"
-			}
-		},
 		"globals": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true
 		},
 		"graceful-fs": {
@@ -2837,31 +5527,22 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
 			"dev": true,
 			"requires": {
-				"async": "^1.4.0",
+				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
-				"source-map": "^0.4.4",
-				"uglify-js": "^2.6"
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
-				},
 				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"dev": true,
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -2872,12 +5553,12 @@
 			"dev": true
 		},
 		"har-validator": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.3.0",
+				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
 			}
 		},
@@ -2890,15 +5571,6 @@
 				"function-bind": "^1.1.1"
 			}
 		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			}
-		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2908,7 +5580,12 @@
 		"has-resolved": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-resolved/-/has-resolved-1.1.0.tgz",
-			"integrity": "sha512-/8aGbzLptuQ+jVgXEhKp2Sd2bZm9ZabJUDUA/2FsbPif0ifCtpoP4HdJjWmeItHttxFTfR1q2tNI0RGeZ7vmxA==",
+			"integrity": "sha512-/8aGbzLptuQ+jVgXEhKp2Sd2bZm9ZabJUDUA/2FsbPif0ifCtpoP4HdJjWmeItHttxFTfR1q2tNI0RGeZ7vmxA=="
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
 			"dev": true
 		},
 		"has-value": {
@@ -2963,16 +5640,6 @@
 				}
 			}
 		},
-		"home-or-tmp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"dev": true,
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
-			}
-		},
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -3013,12 +5680,12 @@
 			}
 		},
 		"import-local": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^2.0.0",
+				"pkg-dir": "^3.0.0",
 				"resolve-cwd": "^2.0.0"
 			}
 		},
@@ -3063,9 +5730,9 @@
 			}
 		},
 		"invert-kv": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
 			"dev": true
 		},
 		"is-accessor-descriptor": {
@@ -3099,15 +5766,6 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
-		"is-builtin-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
-			"requires": {
-				"builtin-modules": "^1.0.0"
-			}
-		},
 		"is-callable": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
@@ -3115,12 +5773,12 @@
 			"dev": true
 		},
 		"is-ci": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz",
-			"integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^1.3.0"
+				"ci-info": "^2.0.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -3157,41 +5815,11 @@
 				}
 			}
 		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
-		},
-		"is-equal-shallow": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
-			"requires": {
-				"is-primitive": "^2.0.0"
-			}
-		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
 			"dev": true
-		},
-		"is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-			"dev": true
-		},
-		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
@@ -3200,28 +5828,25 @@
 			"dev": true
 		},
 		"is-generator-fn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 			"dev": true
 		},
-		"is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"dev": true,
-			"requires": {
-				"is-extglob": "^1.0.0"
-			}
-		},
 		"is-number": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+			"dev": true
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -3231,18 +5856,6 @@
 			"requires": {
 				"isobject": "^3.0.1"
 			}
-		},
-		"is-posix-bracket": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
-		},
-		"is-primitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
@@ -3259,10 +5872,13 @@
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-symbol": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-			"dev": true
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -3274,6 +5890,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
 			"dev": true
 		},
 		"isarray": {
@@ -3308,835 +5930,568 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 			"dev": true
 		},
-		"istanbul-api": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.6.tgz",
-			"integrity": "sha512-luJDnB1uJ5Qsg/WwusGfNXayQ4598yDgW5S0nUS85T576m1LVJzSqLrCDULkT6sTQXVKHa54093gNuCKumMCjQ==",
+		"istanbul-lib-coverage": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+			"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+			"dev": true
+		},
+		"istanbul-lib-instrument": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+			"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
 			"dev": true,
 			"requires": {
-				"async": "^2.1.4",
-				"compare-versions": "^3.1.0",
-				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.2.0",
-				"istanbul-lib-hook": "^1.2.0",
-				"istanbul-lib-instrument": "^2.1.0",
-				"istanbul-lib-report": "^1.1.4",
-				"istanbul-lib-source-maps": "^1.2.5",
-				"istanbul-reports": "^1.4.1",
-				"js-yaml": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"once": "^1.4.0"
+				"@babel/generator": "^7.4.0",
+				"@babel/parser": "^7.4.3",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.3",
+				"@babel/types": "^7.4.0",
+				"istanbul-lib-coverage": "^2.0.5",
+				"semver": "^6.0.0"
 			},
 			"dependencies": {
-				"istanbul-lib-instrument": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz",
-					"integrity": "sha512-l7TD/VnBsIB2OJvSyxaLW/ab1+92dxZNH9wLH7uHPPioy3JZ8tnx2UXUdKmdkgmP2EFPzg64CToUP6dAS3U32Q==",
-					"dev": true,
-					"requires": {
-						"@babel/generator": "7.0.0-beta.51",
-						"@babel/parser": "7.0.0-beta.51",
-						"@babel/template": "7.0.0-beta.51",
-						"@babel/traverse": "7.0.0-beta.51",
-						"@babel/types": "7.0.0-beta.51",
-						"istanbul-lib-coverage": "^2.0.1",
-						"semver": "^5.5.0"
-					},
-					"dependencies": {
-						"istanbul-lib-coverage": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-							"integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
-							"dev": true
-						}
-					}
+				"semver": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"dev": true
 				}
 			}
 		},
-		"istanbul-lib-coverage": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-			"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
-			"dev": true
-		},
-		"istanbul-lib-hook": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz",
-			"integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
-			"dev": true,
-			"requires": {
-				"append-transform": "^1.0.0"
-			}
-		},
-		"istanbul-lib-instrument": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
-			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
-			"dev": true,
-			"requires": {
-				"babel-generator": "^6.18.0",
-				"babel-template": "^6.16.0",
-				"babel-traverse": "^6.18.0",
-				"babel-types": "^6.18.0",
-				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.2.0",
-				"semver": "^5.3.0"
-			}
-		},
 		"istanbul-lib-report": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
-			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+			"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"path-parse": "^1.0.5",
-				"supports-color": "^3.1.2"
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
 				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
-			"integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+			"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.1.0",
-				"istanbul-lib-coverage": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.6.1",
-				"source-map": "^0.5.3"
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"rimraf": "^2.6.3",
+				"source-map": "^0.6.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
 		"istanbul-reports": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.0.tgz",
-			"integrity": "sha512-HeZG0WHretI9FXBni5wZ9DOgNziqDCEwetxnme5k1Vv5e81uTqcsy3fMH99gXGDGKr1ea87TyGseDMa2h4HEUA==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+			"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
 			"dev": true,
 			"requires": {
-				"handlebars": "^4.0.11"
+				"handlebars": "^4.1.2"
 			}
 		},
 		"jest": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.4.tgz",
-			"integrity": "sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",
+			"integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
 			"dev": true,
 			"requires": {
-				"import-local": "^1.0.0",
-				"jest-cli": "^22.4.4"
+				"import-local": "^2.0.0",
+				"jest-cli": "^24.8.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
 				"jest-cli": {
-					"version": "22.4.4",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
-					"integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz",
+					"integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
+						"@jest/core": "^24.8.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.0.1",
 						"exit": "^0.1.2",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"import-local": "^1.0.0",
-						"is-ci": "^1.0.10",
-						"istanbul-api": "^1.1.14",
-						"istanbul-lib-coverage": "^1.1.1",
-						"istanbul-lib-instrument": "^1.8.0",
-						"istanbul-lib-source-maps": "^1.2.1",
-						"jest-changed-files": "^22.2.0",
-						"jest-config": "^22.4.4",
-						"jest-environment-jsdom": "^22.4.1",
-						"jest-get-type": "^22.1.0",
-						"jest-haste-map": "^22.4.2",
-						"jest-message-util": "^22.4.0",
-						"jest-regex-util": "^22.1.0",
-						"jest-resolve-dependencies": "^22.1.0",
-						"jest-runner": "^22.4.4",
-						"jest-runtime": "^22.4.4",
-						"jest-snapshot": "^22.4.0",
-						"jest-util": "^22.4.1",
-						"jest-validate": "^22.4.4",
-						"jest-worker": "^22.2.2",
-						"micromatch": "^2.3.11",
-						"node-notifier": "^5.2.1",
-						"realpath-native": "^1.0.0",
-						"rimraf": "^2.5.4",
-						"slash": "^1.0.0",
-						"string-length": "^2.0.0",
-						"strip-ansi": "^4.0.0",
-						"which": "^1.2.12",
-						"yargs": "^10.0.3"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
+						"import-local": "^2.0.0",
+						"is-ci": "^2.0.0",
+						"jest-config": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
+						"prompts": "^2.0.1",
+						"realpath-native": "^1.1.0",
+						"yargs": "^12.0.2"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
-			"integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
+			"integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
 			"dev": true,
 			"requires": {
+				"@jest/types": "^24.8.0",
+				"execa": "^1.0.0",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
-			"integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
+			"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
 			"dev": true,
 			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/test-sequencer": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"babel-jest": "^24.8.0",
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^22.4.1",
-				"jest-environment-node": "^22.4.1",
-				"jest-get-type": "^22.1.0",
-				"jest-jasmine2": "^22.4.4",
-				"jest-regex-util": "^22.1.0",
-				"jest-resolve": "^22.4.2",
-				"jest-util": "^22.4.1",
-				"jest-validate": "^22.4.4",
-				"pretty-format": "^22.4.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"jest-environment-jsdom": "^24.8.0",
+				"jest-environment-node": "^24.8.0",
+				"jest-get-type": "^24.8.0",
+				"jest-jasmine2": "^24.8.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-validate": "^24.8.0",
+				"micromatch": "^3.1.10",
+				"pretty-format": "^24.8.0",
+				"realpath-native": "^1.1.0"
 			}
 		},
 		"jest-diff": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
-			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+			"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"diff": "^3.2.0",
-				"jest-get-type": "^22.4.3",
-				"pretty-format": "^22.4.3"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"diff-sequences": "^24.3.0",
+				"jest-get-type": "^24.8.0",
+				"pretty-format": "^24.8.0"
 			}
 		},
 		"jest-docblock": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
-			"integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+			"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
 			"dev": true,
 			"requires": {
 				"detect-newline": "^2.1.0"
 			}
 		},
-		"jest-environment-jsdom": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
-			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+		"jest-each": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
+			"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^22.4.3",
-				"jest-util": "^22.4.3",
+				"@jest/types": "^24.8.0",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"pretty-format": "^24.8.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
+			"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.8.0",
+				"@jest/fake-timers": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"jest-mock": "^24.8.0",
+				"jest-util": "^24.8.0",
 				"jsdom": "^11.5.1"
 			}
 		},
 		"jest-environment-node": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
-			"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
+			"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^22.4.3",
-				"jest-util": "^22.4.3"
+				"@jest/environment": "^24.8.0",
+				"@jest/fake-timers": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"jest-mock": "^24.8.0",
+				"jest-util": "^24.8.0"
 			}
 		},
 		"jest-get-type": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+			"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
-			"integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
+			"integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
 			"dev": true,
 			"requires": {
+				"@jest/types": "^24.8.0",
+				"anymatch": "^2.0.0",
 				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"jest-docblock": "^22.4.3",
-				"jest-serializer": "^22.4.3",
-				"jest-worker": "^22.4.3",
-				"micromatch": "^2.3.11",
-				"sane": "^2.0.0"
+				"fsevents": "^1.2.7",
+				"graceful-fs": "^4.1.15",
+				"invariant": "^2.2.4",
+				"jest-serializer": "^24.4.0",
+				"jest-util": "^24.8.0",
+				"jest-worker": "^24.6.0",
+				"micromatch": "^3.1.10",
+				"sane": "^4.0.3",
+				"walker": "^1.0.7"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"dev": true,
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"dev": true
+				}
 			}
 		},
 		"jest-jasmine2": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
-			"integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
+			"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
 			"dev": true,
 			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^24.8.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/types": "^24.8.0",
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
-				"expect": "^22.4.0",
-				"graceful-fs": "^4.1.11",
-				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^22.4.0",
-				"jest-matcher-utils": "^22.4.0",
-				"jest-message-util": "^22.4.0",
-				"jest-snapshot": "^22.4.0",
-				"jest-util": "^22.4.1",
-				"source-map-support": "^0.5.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"source-map-support": {
-					"version": "0.5.9",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"jest-leak-detector": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
-			"integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
-			"dev": true,
-			"requires": {
-				"pretty-format": "^22.4.3"
-			}
-		},
-		"jest-matcher-utils": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
-			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.1",
-				"jest-get-type": "^22.4.3",
-				"pretty-format": "^22.4.3"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"jest-message-util": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
-			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0-beta.35",
-				"chalk": "^2.0.1",
-				"micromatch": "^2.3.11",
-				"slash": "^1.0.0",
-				"stack-utils": "^1.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"jest-mock": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
-			"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
-			"dev": true
-		},
-		"jest-regex-util": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
-			"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
-			"dev": true
-		},
-		"jest-resolve": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
-			"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
-			"dev": true,
-			"requires": {
-				"browser-resolve": "^1.11.2",
-				"chalk": "^2.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"jest-resolve-dependencies": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
-			"integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
-			"dev": true,
-			"requires": {
-				"jest-regex-util": "^22.4.3"
-			}
-		},
-		"jest-runner": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
-			"integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
-			"dev": true,
-			"requires": {
-				"exit": "^0.1.2",
-				"jest-config": "^22.4.4",
-				"jest-docblock": "^22.4.0",
-				"jest-haste-map": "^22.4.2",
-				"jest-jasmine2": "^22.4.4",
-				"jest-leak-detector": "^22.4.0",
-				"jest-message-util": "^22.4.0",
-				"jest-runtime": "^22.4.4",
-				"jest-util": "^22.4.1",
-				"jest-worker": "^22.2.2",
+				"expect": "^24.8.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^24.8.0",
+				"jest-matcher-utils": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-runtime": "^24.8.0",
+				"jest-snapshot": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"pretty-format": "^24.8.0",
 				"throat": "^4.0.0"
 			}
 		},
-		"jest-runtime": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
-			"integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
+		"jest-leak-detector": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
+			"integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-jest": "^22.4.4",
-				"babel-plugin-istanbul": "^4.1.5",
+				"pretty-format": "^24.8.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+			"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
+			"dev": true,
+			"requires": {
 				"chalk": "^2.0.1",
-				"convert-source-map": "^1.4.0",
+				"jest-diff": "^24.8.0",
+				"jest-get-type": "^24.8.0",
+				"pretty-format": "^24.8.0"
+			}
+		},
+		"jest-message-util": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+			"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"@types/stack-utils": "^1.0.1",
+				"chalk": "^2.0.1",
+				"micromatch": "^3.1.10",
+				"slash": "^2.0.0",
+				"stack-utils": "^1.0.1"
+			}
+		},
+		"jest-mock": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+			"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.8.0"
+			}
+		},
+		"jest-pnp-resolver": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+			"dev": true
+		},
+		"jest-regex-util": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+			"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+			"dev": true
+		},
+		"jest-resolve": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+			"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.8.0",
+				"browser-resolve": "^1.11.3",
+				"chalk": "^2.0.1",
+				"jest-pnp-resolver": "^1.2.1",
+				"realpath-native": "^1.1.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
+			"integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.8.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-snapshot": "^24.8.0"
+			}
+		},
+		"jest-runner": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
+			"integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.7.1",
+				"@jest/environment": "^24.8.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"chalk": "^2.4.2",
 				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^22.4.4",
-				"jest-haste-map": "^22.4.2",
-				"jest-regex-util": "^22.1.0",
-				"jest-resolve": "^22.4.2",
-				"jest-util": "^22.4.1",
-				"jest-validate": "^22.4.4",
-				"json-stable-stringify": "^1.0.1",
-				"micromatch": "^2.3.11",
-				"realpath-native": "^1.0.0",
-				"slash": "^1.0.0",
-				"strip-bom": "3.0.0",
-				"write-file-atomic": "^2.1.0",
-				"yargs": "^10.0.3"
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.8.0",
+				"jest-docblock": "^24.3.0",
+				"jest-haste-map": "^24.8.0",
+				"jest-jasmine2": "^24.8.0",
+				"jest-leak-detector": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-resolve": "^24.8.0",
+				"jest-runtime": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-worker": "^24.6.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"dev": true
+				}
+			}
+		},
+		"jest-runtime": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
+			"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.7.1",
+				"@jest/environment": "^24.8.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"@types/yargs": "^12.0.2",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.8.0",
+				"jest-haste-map": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-mock": "^24.8.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.8.0",
+				"jest-snapshot": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-validate": "^24.8.0",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"strip-bom": "^3.0.0",
+				"yargs": "^12.0.2"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"dev": true
 				}
 			}
 		},
 		"jest-serializer": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
-			"integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+			"integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
 			"dev": true
 		},
 		"jest-snapshot": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
-			"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
+			"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
 			"dev": true,
 			"requires": {
+				"@babel/types": "^7.0.0",
+				"@jest/types": "^24.8.0",
 				"chalk": "^2.0.1",
-				"jest-diff": "^22.4.3",
-				"jest-matcher-utils": "^22.4.3",
+				"expect": "^24.8.0",
+				"jest-diff": "^24.8.0",
+				"jest-matcher-utils": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-resolve": "^24.8.0",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^22.4.3"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"pretty-format": "^24.8.0",
+				"semver": "^5.5.0"
 			}
 		},
 		"jest-util": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
-			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
+			"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
 			"dev": true,
 			"requires": {
-				"callsites": "^2.0.0",
+				"@jest/console": "^24.7.1",
+				"@jest/fake-timers": "^24.8.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"callsites": "^3.0.0",
 				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.11",
-				"is-ci": "^1.0.10",
-				"jest-message-util": "^22.4.3",
+				"graceful-fs": "^4.1.15",
+				"is-ci": "^2.0.0",
 				"mkdirp": "^0.5.1",
+				"slash": "^2.0.0",
 				"source-map": "^0.6.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
 		"jest-validate": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
-			"integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
+			"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
 			"dev": true,
 			"requires": {
+				"@jest/types": "^24.8.0",
+				"camelcase": "^5.0.0",
 				"chalk": "^2.0.1",
-				"jest-config": "^22.4.4",
-				"jest-get-type": "^22.1.0",
+				"jest-get-type": "^24.8.0",
 				"leven": "^2.1.0",
-				"pretty-format": "^22.4.0"
+				"pretty-format": "^24.8.0"
+			}
+		},
+		"jest-watcher": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
+			"integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"@types/yargs": "^12.0.9",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"jest-util": "^24.8.0",
+				"string-length": "^2.0.0"
+			}
+		},
+		"jest-worker": {
+			"version": "24.6.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+			"integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
+			"dev": true,
+			"requires": {
+				"merge-stream": "^1.0.1",
+				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
 				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -4144,36 +6499,22 @@
 				}
 			}
 		},
-		"jest-worker": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
-			"integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
-			"dev": true,
-			"requires": {
-				"merge-stream": "^1.0.1"
-			}
+		"js-levenshtein": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+			"integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
-		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-			"dev": true,
-			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			}
-		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"jsdom": {
 			"version": "11.12.0",
@@ -4210,9 +6551,9 @@
 			}
 		},
 		"jsesc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
 		"json-parse-better-errors": {
@@ -4228,36 +6569,15 @@
 			"dev": true
 		},
 		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
-		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
-			"requires": {
-				"jsonify": "~0.0.0"
-			}
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
-		},
-		"json5": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
 			"dev": true
 		},
 		"jsprim": {
@@ -4281,20 +6601,19 @@
 				"is-buffer": "^1.1.5"
 			}
 		},
-		"lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-			"dev": true,
-			"optional": true
+		"kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"dev": true
 		},
 		"lcid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 			"dev": true,
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "^2.0.0"
 			}
 		},
 		"left-pad": {
@@ -4332,19 +6651,19 @@
 			}
 		},
 		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
+				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
-			"version": "4.17.10",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
 			"dev": true
 		},
 		"lodash.sortby": {
@@ -4352,13 +6671,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
-		},
-		"longest": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true,
-			"optional": true
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -4368,14 +6680,28 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"lru-cache": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+		"make-dir": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pify": "^4.0.1",
+				"semver": "^5.6.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"makeerror": {
@@ -4385,6 +6711,15 @@
 			"dev": true,
 			"requires": {
 				"tmpl": "1.0.x"
+			}
+		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"dev": true,
+			"requires": {
+				"p-defer": "^1.0.0"
 			}
 		},
 		"map-cache": {
@@ -4402,31 +6737,21 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-			"dev": true
-		},
 		"mem": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
 			}
 		},
 		"memoize-one": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.2.tgz",
-			"integrity": "sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg=="
-		},
-		"merge": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-			"dev": true
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
+			"integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
 		},
 		"merge-stream": {
 			"version": "1.0.1",
@@ -4438,45 +6763,53 @@
 			}
 		},
 		"micromatch": {
-			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
 			}
 		},
 		"mime-db": {
-			"version": "1.36.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-			"integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.20",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+			"version": "2.1.24",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.36.0"
+				"mime-db": "1.40.0"
 			}
 		},
 		"mimic-fn": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true
 		},
 		"minimatch": {
@@ -4531,9 +6864,9 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-			"integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 			"dev": true,
 			"optional": true
 		},
@@ -4582,6 +6915,18 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"neo-async": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+			"dev": true
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
 		"node-fetch": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -4597,26 +6942,42 @@
 			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
 			"dev": true
 		},
+		"node-modules-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+			"dev": true
+		},
 		"node-notifier": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
 			"dev": true,
 			"requires": {
 				"growly": "^1.3.0",
-				"semver": "^5.4.1",
+				"is-wsl": "^1.1.0",
+				"semver": "^5.5.0",
 				"shellwords": "^0.1.1",
 				"which": "^1.3.0"
 			}
 		},
+		"node-releases": {
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
+			"integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
+			"dev": true,
+			"requires": {
+				"semver": "^5.3.0"
+			}
+		},
 		"normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
+				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
 			}
@@ -4646,9 +7007,9 @@
 			"dev": true
 		},
 		"nwsapi": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+			"integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
 			"dev": true
 		},
 		"oauth-sign": {
@@ -4685,9 +7046,9 @@
 			}
 		},
 		"object-keys": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
 			"dev": true
 		},
 		"object-visit": {
@@ -4707,16 +7068,6 @@
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.5.1"
-			}
-		},
-		"object.omit": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
-			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
@@ -4769,38 +7120,30 @@
 				}
 			}
 		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
-		},
 		"os-locale": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 			"dev": true,
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
 			}
 		},
-		"os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
 			"dev": true
 		},
-		"output-file-sync": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+		"p-each-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.4",
-				"mkdirp": "^0.5.1",
-				"object-assign": "^4.1.0"
+				"p-reduce": "^1.0.0"
 			}
 		},
 		"p-finally": {
@@ -4809,41 +7152,41 @@
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 			"dev": true
 		},
+		"p-is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+			"dev": true
+		},
 		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 			"dev": true,
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "^2.0.0"
 			}
 		},
-		"p-try": {
+		"p-reduce": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
 			"dev": true
 		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
-			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
-			}
+		"p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true
 		},
 		"parse-json": {
 			"version": "4.0.0",
@@ -4866,6 +7209,13 @@
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
 			"dev": true
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true,
+			"optional": true
 		},
 		"path-exists": {
 			"version": "3.0.0",
@@ -4912,13 +7262,22 @@
 			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 			"dev": true
 		},
-		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+		"pirates": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.1.0"
+				"node-modules-regexp": "^1.0.0"
+			}
+		},
+		"pkg-dir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0"
 			}
 		},
 		"pn": {
@@ -4939,37 +7298,16 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
-		"preserve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
-		},
 		"pretty-format": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
-			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+			"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0",
-				"ansi-styles": "^3.2.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				}
+				"@jest/types": "^24.8.0",
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0",
+				"react-is": "^16.8.4"
 			}
 		},
 		"private": {
@@ -4992,6 +7330,16 @@
 				"asap": "~2.0.3"
 			}
 		},
+		"prompts": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
+			"integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
+			"dev": true,
+			"requires": {
+				"kleur": "^3.0.2",
+				"sisteransi": "^1.0.0"
+			}
+		},
 		"prop-types": {
 			"version": "15.6.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
@@ -5001,17 +7349,21 @@
 				"object-assign": "^4.1.1"
 			}
 		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+		"psl": {
+			"version": "1.1.32",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+			"integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
 			"dev": true
 		},
-		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
-			"dev": true
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"punycode": {
 			"version": "2.1.1",
@@ -5025,31 +7377,6 @@
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
 		},
-		"randomatic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-			"integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
-			"dev": true,
-			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				}
-			}
-		},
 		"react": {
 			"version": "16.4.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.4.2.tgz",
@@ -5061,6 +7388,12 @@
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.0"
 			}
+		},
+		"react-is": {
+			"version": "16.8.6",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+			"dev": true
 		},
 		"read-pkg": {
 			"version": "3.0.0",
@@ -5074,12 +7407,12 @@
 			}
 		},
 		"read-pkg-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.0.0",
+				"find-up": "^3.0.0",
 				"read-pkg": "^3.0.0"
 			}
 		},
@@ -5098,23 +7431,10 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
-		"readdirp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"minimatch": "^3.0.2",
-				"readable-stream": "^2.0.2",
-				"set-immediate-shim": "^1.0.1"
-			}
-		},
 		"realpath-native": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.1.tgz",
-			"integrity": "sha512-W14EcXuqUvKP8dkWkD7B95iMy77lpMnlFXbbk409bQtNCbeu0kvRE5reo+yIZ3JXxg6frbGsz2DLQ39lrCB40g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
 			"dev": true,
 			"requires": {
 				"util.promisify": "^1.0.0"
@@ -5126,29 +7446,13 @@
 			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
 			"dev": true
 		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-		},
-		"regenerator-transform": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+		"regenerate-unicode-properties": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+			"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.18.0",
-				"babel-types": "^6.19.0",
-				"private": "^0.1.6"
-			}
-		},
-		"regex-cache": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"dev": true,
-			"requires": {
-				"is-equal-shallow": "^0.1.3"
+				"regenerate": "^1.4.0"
 			}
 		},
 		"regex-not": {
@@ -5161,39 +7465,11 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"regexpu-core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-			"dev": true,
-			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
-			}
-		},
-		"regjsgen": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+		"regexp-tree": {
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.10.tgz",
+			"integrity": "sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ==",
 			"dev": true
-		},
-		"regjsparser": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-			"dev": true,
-			"requires": {
-				"jsesc": "~0.5.0"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
-				}
-			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -5212,15 +7488,6 @@
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 			"dev": true
-		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
-			"requires": {
-				"is-finite": "^1.0.0"
-			}
 		},
 		"request": {
 			"version": "2.88.0",
@@ -5248,26 +7515,44 @@
 				"tough-cookie": "~2.4.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.13.1"
+				"lodash": "^4.17.11"
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
 			"dev": true,
 			"requires": {
-				"request-promise-core": "1.1.1",
-				"stealthy-require": "^1.1.0",
-				"tough-cookie": ">=2.3.3"
+				"request-promise-core": "1.1.2",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
 			}
 		},
 		"require-directory": {
@@ -5277,16 +7562,19 @@
 			"dev": true
 		},
 		"require-main-filename": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+			"integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
 		},
 		"resolve-cwd": {
 			"version": "2.0.0",
@@ -5315,29 +7603,19 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
-		"right-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"align-text": "^0.1.1"
-			}
-		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "^7.1.3"
 			}
 		},
 		"rsvp": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+			"integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
 			"dev": true
 		},
 		"safe-buffer": {
@@ -5361,20 +7639,20 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
-			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+			"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
 			"dev": true,
 			"requires": {
+				"@cnakazawa/watch": "^1.0.3",
 				"anymatch": "^2.0.0",
-				"capture-exit": "^1.2.0",
-				"exec-sh": "^0.2.0",
+				"capture-exit": "^2.0.0",
+				"exec-sh": "^0.3.2",
+				"execa": "^1.0.0",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.3",
 				"micromatch": "^3.1.4",
 				"minimist": "^1.1.1",
-				"walker": "~1.0.5",
-				"watch": "~0.18.0"
+				"walker": "~1.0.5"
 			},
 			"dependencies": {
 				"anymatch": {
@@ -5385,274 +7663,6 @@
 					"requires": {
 						"micromatch": "^3.1.4",
 						"normalize-path": "^2.1.1"
-					}
-				},
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
 					}
 				},
 				"minimist": {
@@ -5680,13 +7690,6 @@
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
-		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-			"dev": true,
-			"optional": true
 		},
 		"set-value": {
 			"version": "2.0.0",
@@ -5743,10 +7746,16 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
 		},
-		"slash": {
+		"sisteransi": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+			"integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+			"dev": true
+		},
+		"slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
 			"dev": true
 		},
 		"snapdragon": {
@@ -5871,12 +7880,21 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.4.18",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"version": "0.5.12",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+			"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
 			"dev": true,
 			"requires": {
-				"source-map": "^0.5.6"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
 			}
 		},
 		"source-map-url": {
@@ -5886,9 +7904,9 @@
 			"dev": true
 		},
 		"spdx-correct": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -5896,9 +7914,9 @@
 			}
 		},
 		"spdx-exceptions": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
 			"dev": true
 		},
 		"spdx-expression-parse": {
@@ -5912,9 +7930,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+			"integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
 			"dev": true
 		},
 		"split-string": {
@@ -5926,16 +7944,10 @@
 				"extend-shallow": "^3.0.0"
 			}
 		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
-		},
 		"sshpk": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
@@ -5950,9 +7962,9 @@
 			}
 		},
 		"stack-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
 			"dev": true
 		},
 		"static-extend": {
@@ -6046,12 +8058,12 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "^4.1.0"
 			}
 		},
 		"strip-bom": {
@@ -6067,10 +8079,13 @@
 			"dev": true
 		},
 		"supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"dev": true
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
@@ -6079,15 +8094,15 @@
 			"dev": true
 		},
 		"test-exclude": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.2.tgz",
-			"integrity": "sha512-2kTGf+3tykCfrWVREgyTR0bmVO0afE6i7zVXi/m+bZZ8ujV89Aulxdcdv32yH+unVFg3Y5o6GA8IzsHnGQuFgQ==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+			"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
+				"glob": "^7.1.3",
 				"minimatch": "^3.0.4",
-				"read-pkg-up": "^3.0.0",
-				"require-main-filename": "^1.0.1"
+				"read-pkg-up": "^4.0.0",
+				"require-main-filename": "^2.0.0"
 			}
 		},
 		"throat": {
@@ -6108,9 +8123,9 @@
 			"dev": true
 		},
 		"to-fast-properties": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"dev": true
 		},
 		"to-object-path": {
@@ -6156,21 +8171,13 @@
 			}
 		},
 		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
 			}
 		},
 		"tr46": {
@@ -6201,8 +8208,7 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -6219,38 +8225,59 @@
 			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
 		},
 		"uglify-js": {
-			"version": "2.8.29",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"version": "3.5.15",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.15.tgz",
+			"integrity": "sha512-fe7aYFotptIddkwcm6YuA0HmknBZ52ZzOsUxZEdhhkSsz7RfjHDX2QDxwKTiv4JQ5t5NhfmpgAK+J7LiDhKSqg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"source-map": "~0.5.1",
-				"uglify-to-browserify": "~1.0.0",
-				"yargs": "~3.10.0"
+				"commander": "~2.20.0",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+				"commander": {
+					"version": "2.20.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
-						"window-size": "0.1.0"
-					}
+					"optional": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
-		"uglify-to-browserify": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+			"dev": true
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
 			"dev": true,
-			"optional": true
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+			"dev": true
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+			"dev": true
 		},
 		"union-value": {
 			"version": "1.0.0",
@@ -6327,6 +8354,22 @@
 				}
 			}
 		},
+		"upath": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+			"dev": true,
+			"optional": true
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -6337,12 +8380,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-			"dev": true
-		},
-		"user-home": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
 			"dev": true
 		},
 		"util-deprecate": {
@@ -6366,15 +8403,6 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 			"dev": true
-		},
-		"v8flags": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-			"dev": true,
-			"requires": {
-				"user-home": "^1.1.1"
-			}
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -6415,24 +8443,6 @@
 				"makeerror": "1.0.x"
 			}
 		},
-		"watch": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
-			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-			"dev": true,
-			"requires": {
-				"exec-sh": "^0.2.0",
-				"minimist": "^1.2.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
-			}
-		},
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -6440,23 +8450,12 @@
 			"dev": true
 		},
 		"whatwg-encoding": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz",
-			"integrity": "sha512-vM9KWN6MP2mIHZ86ytcyIv7e8Cj3KTfO2nd2c8PFDqcI4bxFmQp83ibq4wadq7rL9l9sZV6o9B0LTt8ygGAAXg==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
 			"dev": true,
 			"requires": {
-				"iconv-lite": "0.4.23"
-			},
-			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				}
+				"iconv-lite": "0.4.24"
 			}
 		},
 		"whatwg-fetch": {
@@ -6465,9 +8464,9 @@
 			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"whatwg-mimetype": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
-			"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
 			"dev": true
 		},
 		"whatwg-url": {
@@ -6496,13 +8495,6 @@
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
 		},
-		"window-size": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-			"dev": true,
-			"optional": true
-		},
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -6519,6 +8511,12 @@
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -6538,6 +8536,15 @@
 						"is-fullwidth-code-point": "^1.0.0",
 						"strip-ansi": "^3.0.0"
 					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -6548,9 +8555,9 @@
 			"dev": true
 		},
 		"write-file-atomic": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
@@ -6574,80 +8581,47 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-			"dev": true
-		},
-		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 			"dev": true
 		},
 		"yargs": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
 			"dev": true,
 			"requires": {
 				"cliui": "^4.0.0",
-				"decamelize": "^1.1.1",
-				"find-up": "^2.1.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
 				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
+				"os-locale": "^3.0.0",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^1.0.1",
 				"set-blocking": "^2.0.0",
 				"string-width": "^2.0.0",
 				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^8.1.0"
+				"y18n": "^3.2.1 || ^4.0.0",
+				"yargs-parser": "^11.1.1"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 					"dev": true
-				},
-				"cliui": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
 				}
 			}
 		},
 		"yargs-parser": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				}
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		}
 	}

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -10,22 +10,22 @@
     "watch": "npm run build -- --watch"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.3",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-react": "^6.24.1",
+    "@babel/cli": "^7.4.4",
+    "@babel/core": "^7.4.5",
+    "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+    "@babel/plugin-transform-runtime": "^7.4.4",
+    "@babel/preset-env": "^7.4.5",
+    "@babel/preset-react": "^7.0.0",
     "has-resolved": "^1.1.0",
-    "jest": "^22.4.4",
+    "jest": "^24.8.0",
     "react": "^16.4.2",
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.3"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.4.5",
     "classnames": "^2.2.6",
     "event-as-promise": "^1.0.5",
     "glamor": "^2.20.40",
-    "memoize-one": "^4.0.0"
+    "memoize-one": "^5.0.4"
   }
 }

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -13,63 +13,43 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.0.tgz",
-			"integrity": "sha512-9EWmD0cQAbcXSc+31RIoYgEHx3KQ2CCSMDBhnXrShWvo45TMw+3/55KVxlhkG53kw9tl87DqINgHDgFVhZJV/Q==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+			"integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.0.0",
-				"@babel/helpers": "^7.1.0",
-				"@babel/parser": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0",
+				"@babel/generator": "^7.4.0",
+				"@babel/helpers": "^7.4.3",
+				"@babel/parser": "^7.4.3",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.3",
+				"@babel/types": "^7.4.0",
 				"convert-source-map": "^1.1.0",
-				"debug": "^3.1.0",
-				"json5": "^0.5.0",
-				"lodash": "^4.17.10",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.11",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
-			"integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+			"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
 			"requires": {
-				"@babel/types": "^7.1.3",
+				"@babel/types": "^7.4.4",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.11",
 				"source-map": "^0.5.0",
 				"trim-right": "^1.0.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
@@ -90,32 +70,45 @@
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
-			"integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
+			"integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
 			"requires": {
-				"@babel/types": "^7.0.0",
+				"@babel/types": "^7.3.0",
 				"esutils": "^2.0.0"
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
-			"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+			"integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.0.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-hoist-variables": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
+			}
+		},
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.4.tgz",
+			"integrity": "sha512-UbBHIa2qeAGgyiNR9RszVF7bUHEdgS4JAUNT8SiqrAN6YJVxlOxeLr5pBzb5kan302dejJ9nla4RyKcR1XT6XA==",
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-member-expression-to-functions": "^7.0.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.4.4",
+				"@babel/helper-split-export-declaration": "^7.4.4"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
-			"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
+			"integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
-				"@babel/types": "^7.0.0",
-				"lodash": "^4.17.10"
+				"@babel/types": "^7.4.4",
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
@@ -146,11 +139,11 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
-			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+			"integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -170,16 +163,16 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
-			"integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+			"integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0",
-				"lodash": "^4.17.10"
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/template": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -196,11 +189,11 @@
 			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
 		},
 		"@babel/helper-regex": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+			"integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
@@ -216,14 +209,14 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
-			"integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
+			"integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -236,32 +229,32 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz",
-			"integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/template": "^7.1.0",
 				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.2.0"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
-			"integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+			"integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
 			"requires": {
-				"@babel/template": "^7.1.2",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.1.2"
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/highlight": {
@@ -275,146 +268,160 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
-			"integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w=="
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+			"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.1.0.tgz",
-			"integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-remap-async-to-generator": "^7.1.0",
-				"@babel/plugin-syntax-async-generators": "^7.0.0"
+				"@babel/plugin-syntax-async-generators": "^7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
-			"integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz",
+			"integrity": "sha512-t2ECPNOXsIeK1JxJNKmgbzQtoG27KIlVE61vTqX0DKR9E9sZlVVxWUtEW9D5FlZ8b8j7SBNCHY47GgPKCKlpPg==",
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-member-expression-to-functions": "^7.0.0",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-create-class-features-plugin": "^7.4.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-proposal-decorators": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.0.tgz",
+			"integrity": "sha512-d08TLmXeK/XbgCo7ZeZ+JaeZDtDai/2ctapTRsWWkkmy7G/cqz8DQN/HlWG7RR4YmfXxmExsbU3SuCjlM7AtUg==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.4.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.1.0",
-				"@babel/plugin-syntax-class-properties": "^7.0.0"
+				"@babel/plugin-syntax-decorators": "^7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
-			"integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+			"integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-json-strings": "^7.0.0"
+				"@babel/plugin-syntax-json-strings": "^7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
-			"integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
+			"integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
-			"integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz",
-			"integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+			"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.2.0"
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.5.4"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
-			"integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+			"integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
-		"@babel/plugin-syntax-class-properties": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz",
-			"integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
+		"@babel/plugin-syntax-decorators": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
+			"integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-dynamic-import": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
-			"integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+			"integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-flow": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0.tgz",
-			"integrity": "sha512-zGcuZWiWWDa5qTZ6iAnpG0fnX/GOu49pGR5PFvkQ9GmKNaSphXQnlNXh/LG20sqWtNrx/eB6krzfEzcwvUyeFA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
+			"integrity": "sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-json-strings": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz",
-			"integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+			"integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz",
-			"integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+			"integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
-			"integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
-			"integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
+			"integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
-			"integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+			"integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz",
-			"integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
+			"integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -422,340 +429,402 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
-			"integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+			"integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
-			"integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
+			"integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
-			"integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
+			"integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-define-map": "^7.1.0",
+				"@babel/helper-define-map": "^7.4.4",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.4.4",
+				"@babel/helper-split-export-declaration": "^7.4.4",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
-			"integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+			"integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.3.tgz",
-			"integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
+			"integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0.tgz",
-			"integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.1.3"
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.5.4"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0.tgz",
-			"integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
+			"integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
-			"integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+			"integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
 			"requires": {
 				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-flow-strip-types": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0.tgz",
-			"integrity": "sha512-WhXUNb4It5a19RsgKKbQPrjmy4yWOY1KynpEbNw7bnd1QTcrT/EIl3MJvnGgpgvrKyKbqX7nUNOJfkpLOnoDKA==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.0.tgz",
+			"integrity": "sha512-C4ZVNejHnfB22vI2TYN4RUp2oCmq6cSEAg4RygSvYZUECRqUu9O4PMEMNJ4wsemaRGg27BbgYctG4BZh+AgIHw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-flow": "^7.0.0"
+				"@babel/plugin-syntax-flow": "^7.2.0"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
-			"integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+			"integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
-			"integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+			"integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
-			"integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+			"integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+			"integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.1.0.tgz",
-			"integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
+			"integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
-			"integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
+			"integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-module-transforms": "^7.4.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.1.3.tgz",
-			"integrity": "sha512-PvTxgjxQAq4pvVUZF3mD5gEtVDuId8NtWkJsZLEJZMZAW3TvgQl1pmydLLN1bM8huHFVVU43lf0uvjQj9FRkKw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
+			"integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.0.0",
+				"@babel/helper-hoist-variables": "^7.4.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.1.0.tgz",
-			"integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+			"integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
+			"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+			"requires": {
+				"regexp-tree": "^0.1.6"
+			}
+		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
-			"integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+			"integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",
-			"integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+			"integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-replace-supers": "^7.1.0"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
-			"integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+			"integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
 			"requires": {
-				"@babel/helper-call-delegate": "^7.1.0",
+				"@babel/helper-call-delegate": "^7.4.4",
 				"@babel/helper-get-function-arity": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+			"integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-transform-react-constant-elements": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.0.0.tgz",
-			"integrity": "sha512-z8yrW4KCVcqPYr0r9dHXe7fu3daLzn0r6TQEFoGbXahdrzEwT1d1ux+/EnFcqIHv9uPilUlnRnPIUf7GMO0ehg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.2.0.tgz",
+			"integrity": "sha512-YYQFg6giRFMsZPKUM9v+VcHOdfSQdz9jHCx3akAi3UYgyjndmdYGSXylQ/V+HswQt4fL8IklchD9HTsaOCrWQQ==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-display-name": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
-			"integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+			"integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz",
-			"integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
+			"integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
 			"requires": {
-				"@babel/helper-builder-react-jsx": "^7.0.0",
+				"@babel/helper-builder-react-jsx": "^7.3.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.0.0"
+				"@babel/plugin-syntax-jsx": "^7.2.0"
 			}
 		},
 		"@babel/plugin-transform-react-jsx-self": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0.tgz",
-			"integrity": "sha512-pymy+AK12WO4safW1HmBpwagUQRl9cevNX+82AIAtU1pIdugqcH+nuYP03Ja6B+N4gliAaKWAegIBL/ymALPHA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
+			"integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.0.0"
+				"@babel/plugin-syntax-jsx": "^7.2.0"
 			}
 		},
 		"@babel/plugin-transform-react-jsx-source": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0.tgz",
-			"integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
+			"integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.0.0"
+				"@babel/plugin-syntax-jsx": "^7.2.0"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
-			"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+			"integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
 			"requires": {
-				"regenerator-transform": "^0.13.3"
+				"regenerator-transform": "^0.14.0"
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+			"integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz",
-			"integrity": "sha512-WFLMgzu5DLQEah0lKTJzYb14vd6UiES7PTnXcvrPZ1VrwFeJ+mTbvr65fFAsXYMt2bIoOoC0jk76zY1S7HZjUg==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz",
+			"integrity": "sha512-7Q61bU+uEI7bCUFReT1NKn7/X6sDQsZ7wL1sJ9IYMAO7cI+eg6x9re1cEw2fCRMbbTVyoeUKWSV1M6azEfKCfg==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"resolve": "^1.8.1",
 				"semver": "^5.5.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
-			"integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+			"integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
-			"integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
-			"integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+			"integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
-			"integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+			"integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0.tgz",
-			"integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+			"integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
-		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
-			"integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
+		"@babel/plugin-transform-typescript": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.5.tgz",
+			"integrity": "sha512-RPB/YeGr4ZrFKNwfuQRlMf2lxoCUaU01MTw39/OFE/RiL8HDjtn68BwEPft1P7JN4akyEmjGWAMNldOV7o9V2g==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.1.3"
+				"@babel/plugin-syntax-typescript": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+			"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.5.4"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
-			"integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.5.tgz",
+			"integrity": "sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-proposal-async-generator-functions": "^7.1.0",
-				"@babel/plugin-proposal-json-strings": "^7.0.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
-				"@babel/plugin-syntax-async-generators": "^7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
-				"@babel/plugin-transform-arrow-functions": "^7.0.0",
-				"@babel/plugin-transform-async-to-generator": "^7.1.0",
-				"@babel/plugin-transform-block-scoped-functions": "^7.0.0",
-				"@babel/plugin-transform-block-scoping": "^7.0.0",
-				"@babel/plugin-transform-classes": "^7.1.0",
-				"@babel/plugin-transform-computed-properties": "^7.0.0",
-				"@babel/plugin-transform-destructuring": "^7.0.0",
-				"@babel/plugin-transform-dotall-regex": "^7.0.0",
-				"@babel/plugin-transform-duplicate-keys": "^7.0.0",
-				"@babel/plugin-transform-exponentiation-operator": "^7.1.0",
-				"@babel/plugin-transform-for-of": "^7.0.0",
-				"@babel/plugin-transform-function-name": "^7.1.0",
-				"@babel/plugin-transform-literals": "^7.0.0",
-				"@babel/plugin-transform-modules-amd": "^7.1.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.1.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.0.0",
-				"@babel/plugin-transform-modules-umd": "^7.1.0",
-				"@babel/plugin-transform-new-target": "^7.0.0",
-				"@babel/plugin-transform-object-super": "^7.1.0",
-				"@babel/plugin-transform-parameters": "^7.1.0",
-				"@babel/plugin-transform-regenerator": "^7.0.0",
-				"@babel/plugin-transform-shorthand-properties": "^7.0.0",
-				"@babel/plugin-transform-spread": "^7.0.0",
-				"@babel/plugin-transform-sticky-regex": "^7.0.0",
-				"@babel/plugin-transform-template-literals": "^7.0.0",
-				"@babel/plugin-transform-typeof-symbol": "^7.0.0",
-				"@babel/plugin-transform-unicode-regex": "^7.0.0",
-				"browserslist": "^4.1.0",
+				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+				"@babel/plugin-proposal-json-strings": "^7.2.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-syntax-async-generators": "^7.2.0",
+				"@babel/plugin-syntax-json-strings": "^7.2.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+				"@babel/plugin-transform-arrow-functions": "^7.2.0",
+				"@babel/plugin-transform-async-to-generator": "^7.4.4",
+				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+				"@babel/plugin-transform-block-scoping": "^7.4.4",
+				"@babel/plugin-transform-classes": "^7.4.4",
+				"@babel/plugin-transform-computed-properties": "^7.2.0",
+				"@babel/plugin-transform-destructuring": "^7.4.4",
+				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/plugin-transform-duplicate-keys": "^7.2.0",
+				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+				"@babel/plugin-transform-for-of": "^7.4.4",
+				"@babel/plugin-transform-function-name": "^7.4.4",
+				"@babel/plugin-transform-literals": "^7.2.0",
+				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
+				"@babel/plugin-transform-modules-amd": "^7.2.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.4.4",
+				"@babel/plugin-transform-modules-systemjs": "^7.4.4",
+				"@babel/plugin-transform-modules-umd": "^7.2.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+				"@babel/plugin-transform-new-target": "^7.4.4",
+				"@babel/plugin-transform-object-super": "^7.2.0",
+				"@babel/plugin-transform-parameters": "^7.4.4",
+				"@babel/plugin-transform-property-literals": "^7.2.0",
+				"@babel/plugin-transform-regenerator": "^7.4.5",
+				"@babel/plugin-transform-reserved-words": "^7.2.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
+				"@babel/plugin-transform-spread": "^7.2.0",
+				"@babel/plugin-transform-sticky-regex": "^7.2.0",
+				"@babel/plugin-transform-template-literals": "^7.4.4",
+				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
+				"@babel/plugin-transform-unicode-regex": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"browserslist": "^4.6.0",
+				"core-js-compat": "^3.1.1",
 				"invariant": "^2.2.2",
 				"js-levenshtein": "^1.1.3",
-				"semver": "^5.3.0"
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"@babel/preset-react": {
@@ -770,70 +839,66 @@
 				"@babel/plugin-transform-react-jsx-source": "^7.0.0"
 			}
 		},
-		"@babel/runtime": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-			"integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+		"@babel/preset-typescript": {
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz",
+			"integrity": "sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==",
 			"requires": {
-				"regenerator-runtime": "^0.12.0"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.12.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-				}
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-transform-typescript": "^7.3.2"
+			}
+		},
+		"@babel/runtime": {
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+			"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+			"requires": {
+				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/template": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
-			"integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.1.2",
-				"@babel/types": "^7.1.2"
+				"@babel/parser": "^7.4.4",
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
-			"integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+			"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.1.3",
+				"@babel/generator": "^7.4.4",
 				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/parser": "^7.1.3",
-				"@babel/types": "^7.1.3",
-				"debug": "^3.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/parser": "^7.4.5",
+				"@babel/types": "^7.4.4",
+				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.10"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				}
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/types": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
-			"integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+			"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
 			"requires": {
 				"esutils": "^2.0.2",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.11",
 				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@cnakazawa/watch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+			"requires": {
+				"exec-sh": "^0.3.2",
+				"minimist": "^1.2.0"
 			}
 		},
 		"@csstools/convert-colors": {
@@ -841,202 +906,669 @@
 			"resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
 			"integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
 		},
-		"@svgr/core": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-2.4.1.tgz",
-			"integrity": "sha512-2i1cUbjpKt1KcIP05e10vkmu9Aedp32EFqVcSQ08onbB8lVxJqMPci3Hr54aI14S9cLg4JdcpO0D35HHUtT8oQ==",
+		"@csstools/normalize.css": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-9.0.1.tgz",
+			"integrity": "sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA=="
+		},
+		"@hapi/address": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+			"integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+		},
+		"@hapi/hoek": {
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+			"integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+		},
+		"@hapi/joi": {
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.0.3.tgz",
+			"integrity": "sha512-z6CesJ2YBwgVCi+ci8SI8zixoj8bGFn/vZb9MBPbSyoxsS2PnWYjHcyTM17VLK6tx64YVK38SDIh10hJypB+ig==",
 			"requires": {
-				"camelcase": "^5.0.0",
-				"cosmiconfig": "^5.0.6",
-				"h2x-core": "^1.1.0",
-				"h2x-plugin-jsx": "^1.1.0",
-				"merge-deep": "^3.0.2",
-				"prettier": "^1.14.2",
-				"svgo": "^1.0.5"
+				"@hapi/address": "2.x.x",
+				"@hapi/hoek": "6.x.x",
+				"@hapi/topo": "3.x.x"
+			}
+		},
+		"@hapi/topo": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.0.tgz",
+			"integrity": "sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==",
+			"requires": {
+				"@hapi/hoek": "6.x.x"
+			}
+		},
+		"@jest/console": {
+			"version": "24.7.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
+			"integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+			"requires": {
+				"@jest/source-map": "^24.3.0",
+				"chalk": "^2.0.1",
+				"slash": "^2.0.0"
+			}
+		},
+		"@jest/core": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
+			"integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
+			"requires": {
+				"@jest/console": "^24.7.1",
+				"@jest/reporters": "^24.8.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-changed-files": "^24.8.0",
+				"jest-config": "^24.8.0",
+				"jest-haste-map": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve-dependencies": "^24.8.0",
+				"jest-runner": "^24.8.0",
+				"jest-runtime": "^24.8.0",
+				"jest-snapshot": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-validate": "^24.8.0",
+				"jest-watcher": "^24.8.0",
+				"micromatch": "^3.1.10",
+				"p-each-series": "^1.0.0",
+				"pirates": "^4.0.1",
+				"realpath-native": "^1.1.0",
+				"rimraf": "^2.5.4",
+				"strip-ansi": "^5.0.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
 				}
 			}
 		},
-		"@svgr/webpack": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-2.4.1.tgz",
-			"integrity": "sha512-sMHYq0zbMtSHcc9kVfkYI2zrl88u4mKGyQLgKt7r+ul5nITcncm/EPBhzEUrJY5izdlaU6EvyH8zOhZnfaSmOA==",
+		"@jest/environment": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
+			"integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
 			"requires": {
-				"@babel/core": "^7.0.1",
+				"@jest/fake-timers": "^24.8.0",
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"jest-mock": "^24.8.0"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
+			"integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
+			"requires": {
+				"@jest/types": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-mock": "^24.8.0"
+			}
+		},
+		"@jest/reporters": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
+			"integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
+			"requires": {
+				"@jest/environment": "^24.8.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.2",
+				"istanbul-lib-coverage": "^2.0.2",
+				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-report": "^2.0.4",
+				"istanbul-lib-source-maps": "^3.0.1",
+				"istanbul-reports": "^2.1.1",
+				"jest-haste-map": "^24.8.0",
+				"jest-resolve": "^24.8.0",
+				"jest-runtime": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-worker": "^24.6.0",
+				"node-notifier": "^5.2.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0",
+				"string-length": "^2.0.0"
+			},
+			"dependencies": {
+				"jest-resolve": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+					"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"browser-resolve": "^1.11.3",
+						"chalk": "^2.0.1",
+						"jest-pnp-resolver": "^1.2.1",
+						"realpath-native": "^1.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"@jest/source-map": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.1.15",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"@jest/test-result": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
+			"integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+			"requires": {
+				"@jest/console": "^24.7.1",
+				"@jest/types": "^24.8.0",
+				"@types/istanbul-lib-coverage": "^2.0.0"
+			}
+		},
+		"@jest/test-sequencer": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
+			"integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
+			"requires": {
+				"@jest/test-result": "^24.8.0",
+				"jest-haste-map": "^24.8.0",
+				"jest-runner": "^24.8.0",
+				"jest-runtime": "^24.8.0"
+			}
+		},
+		"@jest/transform": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
+			"integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.8.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"jest-haste-map": "^24.8.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-util": "^24.8.0",
+				"micromatch": "^3.1.10",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.1",
+				"write-file-atomic": "2.4.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"@jest/types": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
+			"integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^1.1.1",
+				"@types/yargs": "^12.0.9"
+			}
+		},
+		"@mrmlnc/readdir-enhanced": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+		},
+		"@svgr/babel-plugin-add-jsx-attribute": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
+			"integrity": "sha512-j7KnilGyZzYr/jhcrSYS3FGWMZVaqyCG0vzMCwzvei0coIkczuYMcniK07nI0aHJINciujjH11T72ICW5eL5Ig=="
+		},
+		"@svgr/babel-plugin-remove-jsx-attribute": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-4.2.0.tgz",
+			"integrity": "sha512-3XHLtJ+HbRCH4n28S7y/yZoEQnRpl0tvTZQsHqvaeNXPra+6vE5tbRliH3ox1yZYPCxrlqaJT/Mg+75GpDKlvQ=="
+		},
+		"@svgr/babel-plugin-remove-jsx-empty-expression": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-4.2.0.tgz",
+			"integrity": "sha512-yTr2iLdf6oEuUE9MsRdvt0NmdpMBAkgK8Bjhl6epb+eQWk6abBaX3d65UZ3E3FWaOwePyUgNyNCMVG61gGCQ7w=="
+		},
+		"@svgr/babel-plugin-replace-jsx-attribute-value": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.2.0.tgz",
+			"integrity": "sha512-U9m870Kqm0ko8beHawRXLGLvSi/ZMrl89gJ5BNcT452fAjtF2p4uRzXkdzvGJJJYBgx7BmqlDjBN/eCp5AAX2w=="
+		},
+		"@svgr/babel-plugin-svg-dynamic-title": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.3.0.tgz",
+			"integrity": "sha512-3eI17Pb3jlg3oqV4Tie069n1SelYKBUpI90txDcnBWk4EGFW+YQGyQjy6iuJAReH0RnpUJ9jUExrt/xniGvhqw=="
+		},
+		"@svgr/babel-plugin-svg-em-dimensions": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.2.0.tgz",
+			"integrity": "sha512-C0Uy+BHolCHGOZ8Dnr1zXy/KgpBOkEUYY9kI/HseHVPeMbluaX3CijJr7D4C5uR8zrc1T64nnq/k63ydQuGt4w=="
+		},
+		"@svgr/babel-plugin-transform-react-native-svg": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.2.0.tgz",
+			"integrity": "sha512-7YvynOpZDpCOUoIVlaaOUU87J4Z6RdD6spYN4eUb5tfPoKGSF9OG2NuhgYnq4jSkAxcpMaXWPf1cePkzmqTPNw=="
+		},
+		"@svgr/babel-plugin-transform-svg-component": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.2.0.tgz",
+			"integrity": "sha512-hYfYuZhQPCBVotABsXKSCfel2slf/yvJY8heTVX1PCTaq/IgASq1IyxPPKJ0chWREEKewIU/JMSsIGBtK1KKxw=="
+		},
+		"@svgr/babel-preset": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-4.3.0.tgz",
+			"integrity": "sha512-Lgy1RJiZumGtv6yJroOxzFuL64kG/eIcivJQ7y9ljVWL+0QXvFz4ix1xMrmjMD+rpJWwj50ayCIcFelevG/XXg==",
+			"requires": {
+				"@svgr/babel-plugin-add-jsx-attribute": "^4.2.0",
+				"@svgr/babel-plugin-remove-jsx-attribute": "^4.2.0",
+				"@svgr/babel-plugin-remove-jsx-empty-expression": "^4.2.0",
+				"@svgr/babel-plugin-replace-jsx-attribute-value": "^4.2.0",
+				"@svgr/babel-plugin-svg-dynamic-title": "^4.3.0",
+				"@svgr/babel-plugin-svg-em-dimensions": "^4.2.0",
+				"@svgr/babel-plugin-transform-react-native-svg": "^4.2.0",
+				"@svgr/babel-plugin-transform-svg-component": "^4.2.0"
+			}
+		},
+		"@svgr/core": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-4.3.0.tgz",
+			"integrity": "sha512-Ycu1qrF5opBgKXI0eQg3ROzupalCZnSDETKCK/3MKN4/9IEmt3jPX/bbBjftklnRW+qqsCEpO0y/X9BTRw2WBg==",
+			"requires": {
+				"@svgr/plugin-jsx": "^4.3.0",
+				"camelcase": "^5.3.1",
+				"cosmiconfig": "^5.2.0"
+			}
+		},
+		"@svgr/hast-util-to-babel-ast": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-4.2.0.tgz",
+			"integrity": "sha512-IvAeb7gqrGB5TH9EGyBsPrMRH/QCzIuAkLySKvH2TLfLb2uqk98qtJamordRQTpHH3e6TORfBXoTo7L7Opo/Ow==",
+			"requires": {
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@svgr/plugin-jsx": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-4.3.0.tgz",
+			"integrity": "sha512-0ab8zJdSOTqPfjZtl89cjq2IOmXXUYV3Fs7grLT9ur1Al3+x3DSp2+/obrYKUGbQUnLq96RMjSZ7Icd+13vwlQ==",
+			"requires": {
+				"@babel/core": "^7.4.3",
+				"@svgr/babel-preset": "^4.3.0",
+				"@svgr/hast-util-to-babel-ast": "^4.2.0",
+				"rehype-parse": "^6.0.0",
+				"unified": "^7.1.0",
+				"vfile": "^4.0.0"
+			}
+		},
+		"@svgr/plugin-svgo": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-4.2.0.tgz",
+			"integrity": "sha512-zUEKgkT172YzHh3mb2B2q92xCnOAMVjRx+o0waZ1U50XqKLrVQ/8dDqTAtnmapdLsGurv8PSwenjLCUpj6hcvw==",
+			"requires": {
+				"cosmiconfig": "^5.2.0",
+				"merge-deep": "^3.0.2",
+				"svgo": "^1.2.1"
+			}
+		},
+		"@svgr/webpack": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-4.1.0.tgz",
+			"integrity": "sha512-d09ehQWqLMywP/PT/5JvXwPskPK9QCXUjiSkAHehreB381qExXf5JFCBWhfEyNonRbkIneCeYM99w+Ud48YIQQ==",
+			"requires": {
+				"@babel/core": "^7.1.6",
 				"@babel/plugin-transform-react-constant-elements": "^7.0.0",
-				"@babel/preset-env": "^7.0.0",
+				"@babel/preset-env": "^7.1.6",
 				"@babel/preset-react": "^7.0.0",
-				"@svgr/core": "^2.4.1",
+				"@svgr/core": "^4.1.0",
+				"@svgr/plugin-jsx": "^4.1.0",
+				"@svgr/plugin-svgo": "^4.0.3",
 				"loader-utils": "^1.1.0"
 			}
 		},
-		"@types/tapable": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.2.tgz",
-			"integrity": "sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ=="
+		"@types/babel__core": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
+			"integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+			"integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+			"integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
+		"@types/istanbul-lib-coverage": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+			"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
+		},
+		"@types/istanbul-lib-report": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+			"integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"@types/istanbul-reports": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+			"integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "*",
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"@types/node": {
+			"version": "12.0.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.3.tgz",
+			"integrity": "sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw=="
+		},
+		"@types/q": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
+		},
+		"@types/stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+		},
+		"@types/unist": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
+		},
+		"@types/vfile": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+			"integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+			"requires": {
+				"@types/node": "*",
+				"@types/unist": "*",
+				"@types/vfile-message": "*"
+			}
+		},
+		"@types/vfile-message": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
+			"integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+			"requires": {
+				"@types/node": "*",
+				"@types/unist": "*"
+			}
+		},
+		"@types/yargs": {
+			"version": "12.0.12",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
+			"integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw=="
+		},
+		"@typescript-eslint/eslint-plugin": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.6.0.tgz",
+			"integrity": "sha512-U224c29E2lo861TQZs6GSmyC0OYeRNg6bE9UVIiFBxN2MlA0nq2dCrgIVyyRbC05UOcrgf2Wk/CF2gGOPQKUSQ==",
+			"requires": {
+				"@typescript-eslint/parser": "1.6.0",
+				"@typescript-eslint/typescript-estree": "1.6.0",
+				"requireindex": "^1.2.0",
+				"tsutils": "^3.7.0"
+			}
+		},
+		"@typescript-eslint/parser": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.6.0.tgz",
+			"integrity": "sha512-VB9xmSbfafI+/kI4gUK3PfrkGmrJQfh0N4EScT1gZXSZyUxpsBirPL99EWZg9MmPG0pzq/gMtgkk7/rAHj4aQw==",
+			"requires": {
+				"@typescript-eslint/typescript-estree": "1.6.0",
+				"eslint-scope": "^4.0.0",
+				"eslint-visitor-keys": "^1.0.0"
+			}
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.6.0.tgz",
+			"integrity": "sha512-A4CanUwfaG4oXobD5y7EXbsOHjCwn8tj1RDd820etpPAjH+Icjc2K9e/DQM1Hac5zH2BSy+u6bjvvF2wwREvYA==",
+			"requires": {
+				"lodash.unescape": "4.0.1",
+				"semver": "5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+				}
+			}
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.6.tgz",
-			"integrity": "sha512-8nkZS48EVsMUU0v6F1LCIOw4RYWLm2plMtbhFTjNgeXmsTNLuU3xTRtnljt9BFQB+iPbLRobkNrCWftWnNC7wQ==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+			"integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
 			"requires": {
-				"@webassemblyjs/helper-module-context": "1.7.6",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.6",
-				"@webassemblyjs/wast-parser": "1.7.6",
-				"mamacro": "^0.0.3"
+				"@webassemblyjs/helper-module-context": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/wast-parser": "1.8.5"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.6.tgz",
-			"integrity": "sha512-VBOZvaOyBSkPZdIt5VBMg3vPWxouuM13dPXGWI1cBh3oFLNcFJ8s9YA7S9l4mPI7+Q950QqOmqj06oa83hNWBA=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+			"integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ=="
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.6.tgz",
-			"integrity": "sha512-SCzhcQWHXfrfMSKcj8zHg1/kL9kb3aa5TN4plc/EREOs5Xop0ci5bdVBApbk2yfVi8aL+Ly4Qpp3/TRAUInjrg=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+			"integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA=="
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.6.tgz",
-			"integrity": "sha512-1/gW5NaGsEOZ02fjnFiU8/OEEXU1uVbv2um0pQ9YVL3IHSkyk6xOwokzyqqO1qDZQUAllb+V8irtClPWntbVqw=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+			"integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q=="
 		},
 		"@webassemblyjs/helper-code-frame": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.6.tgz",
-			"integrity": "sha512-+suMJOkSn9+vEvDvgyWyrJo5vJsWSDXZmJAjtoUq4zS4eqHyXImpktvHOZwXp1XQjO5H+YQwsBgqTQEc0J/5zg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+			"integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
 			"requires": {
-				"@webassemblyjs/wast-printer": "1.7.6"
+				"@webassemblyjs/wast-printer": "1.8.5"
 			}
 		},
 		"@webassemblyjs/helper-fsm": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.6.tgz",
-			"integrity": "sha512-HCS6KN3wgxUihGBW7WFzEC/o8Eyvk0d56uazusnxXthDPnkWiMv+kGi9xXswL2cvfYfeK5yiM17z2K5BVlwypw=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+			"integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow=="
 		},
 		"@webassemblyjs/helper-module-context": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.6.tgz",
-			"integrity": "sha512-e8/6GbY7OjLM+6OsN7f2krC2qYVNaSr0B0oe4lWdmq5sL++8dYDD1TFbD1TdAdWMRTYNr/Qq7ovXWzia2EbSjw==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+			"integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
 			"requires": {
+				"@webassemblyjs/ast": "1.8.5",
 				"mamacro": "^0.0.3"
 			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.6.tgz",
-			"integrity": "sha512-PzYFCb7RjjSdAOljyvLWVqd6adAOabJW+8yRT+NWhXuf1nNZWH+igFZCUK9k7Cx7CsBbzIfXjJc7u56zZgFj9Q=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+			"integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ=="
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.6.tgz",
-			"integrity": "sha512-3GS628ppDPSuwcYlQ7cDCGr4W2n9c4hLzvnRKeuz+lGsJSmc/ADVoYpm1ts2vlB1tGHkjtQMni+yu8mHoMlKlA==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+			"integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.6",
-				"@webassemblyjs/helper-buffer": "1.7.6",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.6",
-				"@webassemblyjs/wasm-gen": "1.7.6"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.6.tgz",
-			"integrity": "sha512-V4cIp0ruyw+hawUHwQLn6o2mFEw4t50tk530oKsYXQhEzKR+xNGDxs/SFFuyTO7X3NzEu4usA3w5jzhl2RYyzQ==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+			"integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.6.tgz",
-			"integrity": "sha512-ojdlG8WpM394lBow4ncTGJoIVZ4aAtNOWHhfAM7m7zprmkVcKK+2kK5YJ9Bmj6/ketTtOn7wGSHCtMt+LzqgYQ==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+			"integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
 			"requires": {
-				"@xtuc/long": "4.2.1"
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.6.tgz",
-			"integrity": "sha512-oId+tLxQ+AeDC34ELRYNSqJRaScB0TClUU6KQfpB8rNT6oelYlz8axsPhf6yPTg7PBJ/Z5WcXmUYiHEWgbbHJw=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+			"integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw=="
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.6.tgz",
-			"integrity": "sha512-pTNjLO3o41v/Vz9VFLl+I3YLImpCSpodFW77pNoH4agn5I6GgSxXHXtvWDTvYJFty0jSeXZWLEmbaSIRUDlekg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+			"integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.6",
-				"@webassemblyjs/helper-buffer": "1.7.6",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.6",
-				"@webassemblyjs/helper-wasm-section": "1.7.6",
-				"@webassemblyjs/wasm-gen": "1.7.6",
-				"@webassemblyjs/wasm-opt": "1.7.6",
-				"@webassemblyjs/wasm-parser": "1.7.6",
-				"@webassemblyjs/wast-printer": "1.7.6"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/helper-wasm-section": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5",
+				"@webassemblyjs/wasm-opt": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5",
+				"@webassemblyjs/wast-printer": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.6.tgz",
-			"integrity": "sha512-mQvFJVumtmRKEUXMohwn8nSrtjJJl6oXwF3FotC5t6e2hlKMh8sIaW03Sck2MDzw9xPogZD7tdP5kjPlbH9EcQ==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+			"integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.6",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.6",
-				"@webassemblyjs/ieee754": "1.7.6",
-				"@webassemblyjs/leb128": "1.7.6",
-				"@webassemblyjs/utf8": "1.7.6"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/ieee754": "1.8.5",
+				"@webassemblyjs/leb128": "1.8.5",
+				"@webassemblyjs/utf8": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.6.tgz",
-			"integrity": "sha512-go44K90fSIsDwRgtHhX14VtbdDPdK2sZQtZqUcMRvTojdozj5tLI0VVJAzLCfz51NOkFXezPeVTAYFqrZ6rI8Q==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+			"integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.6",
-				"@webassemblyjs/helper-buffer": "1.7.6",
-				"@webassemblyjs/wasm-gen": "1.7.6",
-				"@webassemblyjs/wasm-parser": "1.7.6"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.6.tgz",
-			"integrity": "sha512-t1T6TfwNY85pDA/HWPA8kB9xA4sp9ajlRg5W7EKikqrynTyFo+/qDzIpvdkOkOGjlS6d4n4SX59SPuIayR22Yg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+			"integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.6",
-				"@webassemblyjs/helper-api-error": "1.7.6",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.6",
-				"@webassemblyjs/ieee754": "1.7.6",
-				"@webassemblyjs/leb128": "1.7.6",
-				"@webassemblyjs/utf8": "1.7.6"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-api-error": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/ieee754": "1.8.5",
+				"@webassemblyjs/leb128": "1.8.5",
+				"@webassemblyjs/utf8": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wast-parser": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.6.tgz",
-			"integrity": "sha512-1MaWTErN0ziOsNUlLdvwS+NS1QWuI/kgJaAGAMHX8+fMJFgOJDmN/xsG4h/A1Gtf/tz5VyXQciaqHZqp2q0vfg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+			"integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.6",
-				"@webassemblyjs/floating-point-hex-parser": "1.7.6",
-				"@webassemblyjs/helper-api-error": "1.7.6",
-				"@webassemblyjs/helper-code-frame": "1.7.6",
-				"@webassemblyjs/helper-fsm": "1.7.6",
-				"@xtuc/long": "4.2.1",
-				"mamacro": "^0.0.3"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/floating-point-hex-parser": "1.8.5",
+				"@webassemblyjs/helper-api-error": "1.8.5",
+				"@webassemblyjs/helper-code-frame": "1.8.5",
+				"@webassemblyjs/helper-fsm": "1.8.5",
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.6.tgz",
-			"integrity": "sha512-vHdHSK1tOetvDcl1IV1OdDeGNe/NDDQ+KzuZHMtqTVP1xO/tZ/IKNpj5BaGk1OYFdsDWQqb31PIwdEyPntOWRQ==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+			"integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.6",
-				"@webassemblyjs/wast-parser": "1.7.6",
-				"@xtuc/long": "4.2.1"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/wast-parser": "1.8.5",
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@xtuc/ieee754": {
@@ -1045,9 +1577,9 @@
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
 		},
 		"@xtuc/long": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
-			"integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g=="
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
 		},
 		"abab": {
 			"version": "2.0.0",
@@ -1055,52 +1587,42 @@
 			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
 		},
 		"accepts": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
 			"requires": {
-				"mime-types": "~2.1.18",
-				"negotiator": "0.6.1"
+				"mime-types": "~2.1.24",
+				"negotiator": "0.6.2"
 			}
 		},
 		"acorn": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
-			"integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw=="
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+			"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
 		},
 		"acorn-dynamic-import": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-			"requires": {
-				"acorn": "^5.0.0"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
 		},
 		"acorn-globals": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
-			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
 			"requires": {
 				"acorn": "^6.0.1",
 				"acorn-walk": "^6.0.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
-					"integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg=="
-				}
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
-			"integrity": "sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg=="
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
 		},
 		"acorn-walk": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz",
-			"integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg=="
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
 		},
 		"address": {
 			"version": "1.0.3",
@@ -1108,25 +1630,25 @@
 			"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
 		},
 		"ajv": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
+				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
 			}
 		},
 		"ajv-errors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
-			"integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
 		},
 		"ajv-keywords": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw=="
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -1134,14 +1656,14 @@
 			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
 		},
 		"ansi-colors": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.1.tgz",
-			"integrity": "sha512-Xt+zb6nqgvV9SWAVp0EG3lRsHcbq5DDgqjPPz6pwgtj6RKz65zGXMNa82oJfOSBA/to6GmRP7Dr+6o+kbApTzQ=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+			"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
 		},
 		"ansi-escapes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
 		},
 		"ansi-html": {
 			"version": "0.0.7",
@@ -1149,9 +1671,9 @@
 			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
 		},
 		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -1168,259 +1690,6 @@
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				}
-			}
-		},
-		"append-transform": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-			"requires": {
-				"default-require-extensions": "^1.0.0"
 			}
 		},
 		"aproba": {
@@ -1446,12 +1715,9 @@
 			}
 		},
 		"arr-diff": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"requires": {
-				"arr-flatten": "^1.0.1"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
@@ -1474,9 +1740,9 @@
 			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
 		},
 		"array-flatten": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+			"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
 		},
 		"array-includes": {
 			"version": "3.0.3",
@@ -1511,9 +1777,9 @@
 			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
 		},
 		"array-unique": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"arrify": {
 			"version": "1.0.1",
@@ -1544,10 +1810,11 @@
 			}
 		},
 		"assert": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+			"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
 			"requires": {
+				"object-assign": "^4.1.1",
 				"util": "0.10.3"
 			},
 			"dependencies": {
@@ -1587,17 +1854,14 @@
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
 		},
 		"async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-			"requires": {
-				"lodash": "^4.17.10"
-			}
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 		},
 		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
 		},
 		"async-limiter": {
 			"version": "1.0.0",
@@ -1615,28 +1879,16 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"autoprefixer": {
-			"version": "9.3.1",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.3.1.tgz",
-			"integrity": "sha512-DY9gOh8z3tnCbJ13JIWaeQsoYncTGdsrgCceBaQSIL4nvdrLxgbRSBPevg2XbX7u4QCSfLheSJEEIUUSlkbx6Q==",
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
+			"integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
 			"requires": {
-				"browserslist": "^4.3.3",
-				"caniuse-lite": "^1.0.30000898",
+				"browserslist": "^4.5.4",
+				"caniuse-lite": "^1.0.30000957",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.5",
+				"postcss": "^7.0.14",
 				"postcss-value-parser": "^3.3.1"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"aws-sign2": {
@@ -1667,6 +1919,11 @@
 				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -1674,7 +1931,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -1689,6 +1946,14 @@
 					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
 					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -1696,15 +1961,10 @@
 				}
 			}
 		},
-		"babel-core": {
-			"version": "7.0.0-bridge.0",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-			"integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
-		},
 		"babel-eslint": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
-			"integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
+			"integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.0.0",
@@ -1712,6 +1972,17 @@
 				"@babel/types": "^7.0.0",
 				"eslint-scope": "3.7.1",
 				"eslint-visitor-keys": "^1.0.0"
+			},
+			"dependencies": {
+				"eslint-scope": {
+					"version": "3.7.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+					"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				}
 			}
 		},
 		"babel-extract-comments": {
@@ -1722,68 +1993,29 @@
 				"babylon": "^6.18.0"
 			}
 		},
-		"babel-generator": {
-			"version": "6.26.1",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
-			}
-		},
-		"babel-helpers": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
 		"babel-jest": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
-			"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
+			"integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
 			"requires": {
-				"babel-plugin-istanbul": "^4.1.6",
-				"babel-preset-jest": "^23.2.0"
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"@types/babel__core": "^7.1.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"babel-preset-jest": "^24.6.0",
+				"chalk": "^2.4.2",
+				"slash": "^2.0.0"
 			}
 		},
 		"babel-loader": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.4.tgz",
-			"integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.5.tgz",
+			"integrity": "sha512-NTnHnVRd2JnRqPC0vW+iOQWU5pchDbYXsG2E6DMXEpMfUcQKclF9gmf3G3ZMhzG7IG9ji4coL0cm+FxeWxDpnw==",
 			"requires": {
-				"find-cache-dir": "^1.0.0",
+				"find-cache-dir": "^2.0.0",
 				"loader-utils": "^1.0.2",
 				"mkdirp": "^0.5.1",
 				"util.promisify": "^1.0.0"
-			}
-		},
-		"babel-messages": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-dynamic-import-node": {
@@ -1795,38 +2027,41 @@
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "4.1.6",
-			"resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+			"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
-				"find-up": "^2.1.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"test-exclude": "^4.2.1"
+				"find-up": "^3.0.0",
+				"istanbul-lib-instrument": "^3.3.0",
+				"test-exclude": "^5.2.3"
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
-			"integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc="
+			"version": "24.6.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+			"integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+			"requires": {
+				"@types/babel__traverse": "^7.0.6"
+			}
 		},
 		"babel-plugin-macros": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz",
-			"integrity": "sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz",
+			"integrity": "sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==",
 			"requires": {
-				"cosmiconfig": "^5.0.5",
-				"resolve": "^1.8.1"
+				"@babel/runtime": "^7.4.2",
+				"cosmiconfig": "^5.2.0",
+				"resolve": "^1.10.0"
 			}
 		},
 		"babel-plugin-named-asset-import": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.2.2.tgz",
-			"integrity": "sha512-NtESBqk8LZuNhBd1BMLxDOh0JPytMs88LwAZFmHg1ZyuGrIAO40dw7p624w+flj0uuhfKTNY8tYKsUEAZGRRFA=="
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.2.tgz",
+			"integrity": "sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ=="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
 			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -1839,97 +2074,135 @@
 			}
 		},
 		"babel-plugin-transform-react-remove-prop-types": {
-			"version": "0.4.18",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.18.tgz",
-			"integrity": "sha512-azed2nHo8vmOy7EY26KH+om5oOcWRs0r1U8wOmhwta+SBMMnmJ4H6yaBZRCcHBtMeWp9AVhvBTL/lpR1kEx+Xw=="
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+			"integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
 		},
 		"babel-preset-jest": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
-			"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
+			"version": "24.6.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+			"integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
 			"requires": {
-				"babel-plugin-jest-hoist": "^23.2.0",
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"babel-plugin-jest-hoist": "^24.6.0"
 			}
 		},
 		"babel-preset-react-app": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-5.0.4.tgz",
-			"integrity": "sha512-NQ344N1BXY4ur8c7iRqj1JQvcI6tiLbNB8W2z0Vanmc6xld+EG9CYk9cfIFTPgk5RCkughimt+0uw2nd2CyevQ==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-9.0.0.tgz",
+			"integrity": "sha512-YVsDA8HpAKklhFLJtl9+AgaxrDaor8gGvDFlsg1ByOS0IPGUovumdv4/gJiAnLcDmZmKlH6+9sVOz4NVW7emAg==",
 			"requires": {
-				"@babel/core": "7.1.0",
-				"@babel/plugin-proposal-class-properties": "7.1.0",
-				"@babel/plugin-proposal-object-rest-spread": "7.0.0",
-				"@babel/plugin-syntax-dynamic-import": "7.0.0",
-				"@babel/plugin-transform-classes": "7.1.0",
-				"@babel/plugin-transform-destructuring": "7.0.0",
-				"@babel/plugin-transform-flow-strip-types": "7.0.0",
-				"@babel/plugin-transform-react-constant-elements": "7.0.0",
-				"@babel/plugin-transform-react-display-name": "7.0.0",
-				"@babel/plugin-transform-runtime": "7.1.0",
-				"@babel/preset-env": "7.1.0",
+				"@babel/core": "7.4.3",
+				"@babel/plugin-proposal-class-properties": "7.4.0",
+				"@babel/plugin-proposal-decorators": "7.4.0",
+				"@babel/plugin-proposal-object-rest-spread": "7.4.3",
+				"@babel/plugin-syntax-dynamic-import": "7.2.0",
+				"@babel/plugin-transform-classes": "7.4.3",
+				"@babel/plugin-transform-destructuring": "7.4.3",
+				"@babel/plugin-transform-flow-strip-types": "7.4.0",
+				"@babel/plugin-transform-react-constant-elements": "7.2.0",
+				"@babel/plugin-transform-react-display-name": "7.2.0",
+				"@babel/plugin-transform-runtime": "7.4.3",
+				"@babel/preset-env": "7.4.3",
 				"@babel/preset-react": "7.0.0",
-				"@babel/runtime": "7.0.0",
-				"babel-loader": "8.0.4",
+				"@babel/preset-typescript": "7.3.3",
+				"@babel/runtime": "7.4.3",
 				"babel-plugin-dynamic-import-node": "2.2.0",
-				"babel-plugin-macros": "2.4.2",
-				"babel-plugin-transform-react-remove-prop-types": "0.4.18"
+				"babel-plugin-macros": "2.5.1",
+				"babel-plugin-transform-react-remove-prop-types": "0.4.24"
 			},
 			"dependencies": {
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
+					"integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+					}
+				},
+				"@babel/plugin-transform-classes": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
+					"integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.0.0",
+						"@babel/helper-define-map": "^7.4.0",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.4.0",
+						"@babel/helper-split-export-declaration": "^7.4.0",
+						"globals": "^11.1.0"
+					}
+				},
 				"@babel/plugin-transform-destructuring": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0.tgz",
-					"integrity": "sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==",
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
+					"integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
 					"requires": {
 						"@babel/helper-plugin-utils": "^7.0.0"
 					}
-				}
-			}
-		},
-		"babel-register": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
-			},
-			"dependencies": {
-				"babel-core": {
-					"version": "6.26.3",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+				},
+				"@babel/preset-env": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
+					"integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
 					"requires": {
-						"babel-code-frame": "^6.26.0",
-						"babel-generator": "^6.26.0",
-						"babel-helpers": "^6.24.1",
-						"babel-messages": "^6.23.0",
-						"babel-register": "^6.26.0",
-						"babel-runtime": "^6.26.0",
-						"babel-template": "^6.26.0",
-						"babel-traverse": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"convert-source-map": "^1.5.1",
-						"debug": "^2.6.9",
-						"json5": "^0.5.1",
-						"lodash": "^4.17.4",
-						"minimatch": "^3.0.4",
-						"path-is-absolute": "^1.0.1",
-						"private": "^0.1.8",
-						"slash": "^1.0.0",
-						"source-map": "^0.5.7"
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+						"@babel/plugin-proposal-json-strings": "^7.2.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.4.3",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
+						"@babel/plugin-syntax-async-generators": "^7.2.0",
+						"@babel/plugin-syntax-json-strings": "^7.2.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-transform-arrow-functions": "^7.2.0",
+						"@babel/plugin-transform-async-to-generator": "^7.4.0",
+						"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+						"@babel/plugin-transform-block-scoping": "^7.4.0",
+						"@babel/plugin-transform-classes": "^7.4.3",
+						"@babel/plugin-transform-computed-properties": "^7.2.0",
+						"@babel/plugin-transform-destructuring": "^7.4.3",
+						"@babel/plugin-transform-dotall-regex": "^7.4.3",
+						"@babel/plugin-transform-duplicate-keys": "^7.2.0",
+						"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+						"@babel/plugin-transform-for-of": "^7.4.3",
+						"@babel/plugin-transform-function-name": "^7.4.3",
+						"@babel/plugin-transform-literals": "^7.2.0",
+						"@babel/plugin-transform-member-expression-literals": "^7.2.0",
+						"@babel/plugin-transform-modules-amd": "^7.2.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.4.3",
+						"@babel/plugin-transform-modules-systemjs": "^7.4.0",
+						"@babel/plugin-transform-modules-umd": "^7.2.0",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
+						"@babel/plugin-transform-new-target": "^7.4.0",
+						"@babel/plugin-transform-object-super": "^7.2.0",
+						"@babel/plugin-transform-parameters": "^7.4.3",
+						"@babel/plugin-transform-property-literals": "^7.2.0",
+						"@babel/plugin-transform-regenerator": "^7.4.3",
+						"@babel/plugin-transform-reserved-words": "^7.2.0",
+						"@babel/plugin-transform-shorthand-properties": "^7.2.0",
+						"@babel/plugin-transform-spread": "^7.2.0",
+						"@babel/plugin-transform-sticky-regex": "^7.2.0",
+						"@babel/plugin-transform-template-literals": "^7.2.0",
+						"@babel/plugin-transform-typeof-symbol": "^7.2.0",
+						"@babel/plugin-transform-unicode-regex": "^7.4.3",
+						"@babel/types": "^7.4.0",
+						"browserslist": "^4.5.2",
+						"core-js-compat": "^3.0.0",
+						"invariant": "^2.2.2",
+						"js-levenshtein": "^1.1.3",
+						"semver": "^5.5.0"
 					}
 				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -1940,58 +2213,12 @@
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
-			}
-		},
-		"babel-template": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-traverse": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
 			},
 			"dependencies": {
-				"globals": {
-					"version": "9.18.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-				}
-			}
-		},
-		"babel-types": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
-			},
-			"dependencies": {
-				"to-fast-properties": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 				}
 			}
 		},
@@ -1999,6 +2226,11 @@
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
 			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+		},
+		"bail": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+			"integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -2078,31 +2310,20 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"bfj": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.1.tgz",
-			"integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
-			"requires": {
-				"bluebird": "^3.5.1",
-				"check-types": "^7.3.0",
-				"hoopy": "^0.1.2",
-				"tryer": "^1.0.0"
-			}
-		},
 		"big.js": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
 		},
 		"binary-extensions": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-			"integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
 		},
 		"bluebird": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-			"integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -2110,29 +2331,44 @@
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"body-parser": {
-			"version": "1.18.3",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
 			"requires": {
-				"bytes": "3.0.0",
+				"bytes": "3.1.0",
 				"content-type": "~1.0.4",
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
-				"http-errors": "~1.6.3",
-				"iconv-lite": "0.4.23",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
 				"on-finished": "~2.3.0",
-				"qs": "6.5.2",
-				"raw-body": "2.3.3",
-				"type-is": "~1.6.16"
+				"qs": "6.7.0",
+				"raw-body": "2.4.0",
+				"type-is": "~1.6.17"
 			},
 			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+				"bytes": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+					"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
+						"ms": "2.0.0"
 					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
 				}
 			}
 		},
@@ -2169,13 +2405,30 @@
 			}
 		},
 		"braces": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"brorand": {
@@ -2205,7 +2458,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
 				"buffer-xor": "^1.0.3",
@@ -2239,7 +2492,7 @@
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
-			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -2269,13 +2522,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
-			"integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
+			"integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30000899",
-				"electron-to-chromium": "^1.3.82",
-				"node-releases": "^1.0.1"
+				"caniuse-lite": "^1.0.30000971",
+				"electron-to-chromium": "^1.3.137",
+				"node-releases": "^1.1.21"
 			}
 		},
 		"bser": {
@@ -2288,7 +2541,7 @@
 		},
 		"buffer": {
 			"version": "4.9.1",
-			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"requires": {
 				"base64-js": "^1.0.2",
@@ -2311,11 +2564,6 @@
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
 			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
 		},
-		"builtin-modules": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -2327,31 +2575,24 @@
 			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 		},
 		"cacache": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.2.0.tgz",
-			"integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+			"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
 			"requires": {
-				"bluebird": "^3.5.1",
-				"chownr": "^1.0.1",
-				"figgy-pudding": "^3.1.0",
-				"glob": "^7.1.2",
-				"graceful-fs": "^4.1.11",
-				"lru-cache": "^4.1.3",
+				"bluebird": "^3.5.3",
+				"chownr": "^1.1.1",
+				"figgy-pudding": "^3.5.1",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"lru-cache": "^5.1.1",
 				"mississippi": "^3.0.0",
 				"mkdirp": "^0.5.1",
 				"move-concurrently": "^1.0.1",
 				"promise-inflight": "^1.0.1",
 				"rimraf": "^2.6.2",
-				"ssri": "^6.0.0",
-				"unique-filename": "^1.1.0",
+				"ssri": "^6.0.1",
+				"unique-filename": "^1.1.1",
 				"y18n": "^4.0.0"
-			},
-			"dependencies": {
-				"y18n": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-				}
 			}
 		},
 		"cache-base": {
@@ -2370,18 +2611,31 @@
 				"unset-value": "^1.0.0"
 			}
 		},
-		"caller-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+		},
+		"caller-callsite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
 			"requires": {
-				"callsites": "^0.2.0"
+				"callsites": "^2.0.0"
+			}
+		},
+		"caller-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+			"requires": {
+				"caller-callsite": "^2.0.0"
 			}
 		},
 		"callsites": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 		},
 		"camel-case": {
 			"version": "3.0.0",
@@ -2391,6 +2645,11 @@
 				"no-case": "^2.2.0",
 				"upper-case": "^1.1.1"
 			}
+		},
+		"camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"caniuse-api": {
 			"version": "3.0.0",
@@ -2404,32 +2663,37 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000899",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000899.tgz",
-			"integrity": "sha512-enC3zKfUCJxxwvUIsBkbHd54CtJw1KtIWvrK0JZxWD/fEN2knHaai45lndJ4xXAkyRAPyk60J3yagkKDWhfeMA=="
+			"version": "1.0.30000971",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
+			"integrity": "sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g=="
 		},
 		"capture-exit": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
-			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+			"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
 			"requires": {
-				"rsvp": "^3.3.3"
+				"rsvp": "^4.8.4"
 			}
 		},
 		"case-sensitive-paths-webpack-plugin": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.2.tgz",
-			"integrity": "sha512-oEZgAFfEvKtjSRCu6VgYkuGxwrWXMnQzyBmlLPP7r6PWQVtHxP5Z5N6XsuJvtoVax78am/r7lr46bwo3IVEBOg=="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.2.0.tgz",
+			"integrity": "sha512-u5ElzokS8A1pm9vM3/iDgTcI3xqHxuCao94Oz8etI3cf0Tio0p8izkDYbTIn09uP3yUUr6+veaE6IkjnTYS46g=="
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
+		"ccount": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
+			"integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w=="
+		},
 		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -2441,111 +2705,510 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 		},
-		"check-types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
-			"integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg=="
-		},
 		"chokidar": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+			"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
 			"requires": {
 				"anymatch": "^2.0.0",
-				"async-each": "^1.0.0",
-				"braces": "^2.3.0",
-				"fsevents": "^1.2.2",
+				"async-each": "^1.0.1",
+				"braces": "^2.3.2",
+				"fsevents": "^1.2.7",
 				"glob-parent": "^3.1.0",
-				"inherits": "^2.0.1",
+				"inherits": "^2.0.3",
 				"is-binary-path": "^1.0.0",
 				"is-glob": "^4.0.0",
-				"lodash.debounce": "^4.0.8",
-				"normalize-path": "^2.1.1",
+				"normalize-path": "^3.0.0",
 				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0",
-				"upath": "^1.0.5"
+				"readdirp": "^2.2.1",
+				"upath": "^1.1.1"
 			},
 			"dependencies": {
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+				"fsevents": {
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+					"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+					"optional": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					}
-				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
+						"nan": "^2.12.1",
+						"node-pre-gyp": "^0.12.0"
 					},
 					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.5",
+							"bundled": true,
+							"optional": true,
 							"requires": {
-								"is-extglob": "^2.1.0"
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
 							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"optional": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"optional": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "4.1.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"deep-extend": {
+							"version": "0.6.0",
+							"bundled": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.24",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"optional": true
+						},
+						"minipass": {
+							"version": "2.3.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.2.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.3.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"debug": "^4.1.0",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.12.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.1",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.2.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.6",
+							"bundled": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.4.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.8",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.6.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.7.0",
+							"bundled": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.8",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.3.4",
+								"minizlib": "^1.1.1",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2 || 2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"yallist": {
+							"version": "3.0.3",
+							"bundled": true,
+							"optional": true
 						}
 					}
 				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-				},
-				"is-glob": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
+				"normalize-path": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 				}
 			}
 		},
@@ -2555,17 +3218,17 @@
 			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
 		},
 		"chrome-trace-event": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
-			"integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+			"integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
 		},
 		"ci-info": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
 		},
 		"cipher-base": {
 			"version": "1.0.4",
@@ -2575,11 +3238,6 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"circular-json": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -2613,6 +3271,13 @@
 			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
 			"requires": {
 				"source-map": "~0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"cli-cursor": {
@@ -2627,6 +3292,16 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+		},
+		"cliui": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"requires": {
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
+			}
 		},
 		"clone-deep": {
 			"version": "0.2.4",
@@ -2646,10 +3321,12 @@
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"coa": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/coa/-/coa-2.0.1.tgz",
-			"integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+			"integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
 			"requires": {
+				"@types/q": "^1.5.1",
+				"chalk": "^2.4.1",
 				"q": "^1.1.2"
 			}
 		},
@@ -2668,9 +3345,9 @@
 			}
 		},
 		"color": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
-			"integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
+			"integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
 			"requires": {
 				"color-convert": "^1.9.1",
 				"color-string": "^1.5.2"
@@ -2698,23 +3375,23 @@
 				"simple-swizzle": "^0.2.2"
 			}
 		},
-		"colors": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
-		},
 		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"comma-separated-tokens": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.7.tgz",
+			"integrity": "sha512-Jrx3xsP4pPv4AwJUDWY9wOXGtwPXARej6Xd99h4TUGotmf8APuquKMpK+dnD3UgyxK7OEWaisjZz+3b5jtL6xQ=="
+		},
 		"commander": {
-			"version": "2.17.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
 		},
 		"common-tags": {
 			"version": "1.8.0",
@@ -2727,30 +3404,45 @@
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
 		"component-emitter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
 		},
 		"compressible": {
-			"version": "2.0.15",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
-			"integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+			"integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
 			"requires": {
-				"mime-db": ">= 1.36.0 < 2"
+				"mime-db": ">= 1.40.0 < 2"
 			}
 		},
 		"compression": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
-			"integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+			"integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
 			"requires": {
 				"accepts": "~1.3.5",
 				"bytes": "3.0.0",
-				"compressible": "~2.0.14",
+				"compressible": "~2.0.16",
 				"debug": "2.6.9",
-				"on-headers": "~1.0.1",
+				"on-headers": "~1.0.2",
 				"safe-buffer": "5.1.2",
 				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"concat-map": {
@@ -2770,14 +3462,14 @@
 			}
 		},
 		"confusing-browser-globals": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.4.tgz",
-			"integrity": "sha512-oS1wYNQBHNxM7xnwetiG8X4QjEbWwSzQjcBTtsz0HTNLCTBsepo12z557p9I9F9gYCHaVGQ3rcJD/tQgprGlRA=="
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz",
+			"integrity": "sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ=="
 		},
 		"connect-history-api-fallback": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+			"integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
 		},
 		"console-browserify": {
 			"version": "1.1.0",
@@ -2798,9 +3490,12 @@
 			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
 		},
 		"content-disposition": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+			"requires": {
+				"safe-buffer": "5.1.2"
+			}
 		},
 		"content-type": {
 			"version": "1.0.4",
@@ -2816,9 +3511,9 @@
 			}
 		},
 		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
 		},
 		"cookie-signature": {
 			"version": "1.0.6",
@@ -2848,18 +3543,41 @@
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
 			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
+		"core-js-compat": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.3.tgz",
+			"integrity": "sha512-EP018pVhgwsKHz3YoN1hTq49aRe+h017Kjz0NQz3nXV0cCRMvH3fLQl+vEPGr4r4J5sk4sU3tUC7U1aqTCeJeA==",
+			"requires": {
+				"browserslist": "^4.6.0",
+				"core-js-pure": "3.1.3",
+				"semver": "^6.1.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ=="
+				}
+			}
+		},
+		"core-js-pure": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.3.tgz",
+			"integrity": "sha512-k3JWTrcQBKqjkjI0bkfXS0lbpWPxYuHWfMMjC1VDmzU4Q58IwSbuXSo99YO/hUHlw/EB4AlfA2PVxOGkrIq6dA=="
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
-			"integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+			"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
 			"requires": {
+				"import-fresh": "^2.0.0",
 				"is-directory": "^0.3.1",
-				"js-yaml": "^3.9.0",
+				"js-yaml": "^3.13.1",
 				"parse-json": "^4.0.0"
 			}
 		},
@@ -2874,7 +3592,7 @@
 		},
 		"create-hash": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
 				"cipher-base": "^1.0.1",
@@ -2886,7 +3604,7 @@
 		},
 		"create-hmac": {
 			"version": "1.1.7",
-			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
 				"cipher-base": "^1.0.3",
@@ -2907,6 +3625,13 @@
 				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"crypto-browserify": {
@@ -2927,9 +3652,17 @@
 				"randomfill": "^1.0.3"
 			}
 		},
+		"css-blank-pseudo": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
+			"integrity": "sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==",
+			"requires": {
+				"postcss": "^7.0.5"
+			}
+		},
 		"css-color-names": {
 			"version": "0.0.4",
-			"resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
 			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
 		},
 		"css-declaration-sorter": {
@@ -2939,16 +3672,30 @@
 			"requires": {
 				"postcss": "^7.0.1",
 				"timsort": "^0.3.0"
+			}
+		},
+		"css-has-pseudo": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
+			"integrity": "sha512-Z8hnfsZu4o/kt+AuFzeGpLVhFOGO9mluyHBaA2bA8aCGTwah5sT3WV/fTHH8UNZUytOIImuGPrl/prlb4oX4qQ==",
+			"requires": {
+				"postcss": "^7.0.6",
+				"postcss-selector-parser": "^5.0.0-rc.4"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+				},
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				}
 			}
@@ -2963,22 +3710,36 @@
 			}
 		},
 		"css-loader": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
-			"integrity": "sha512-tMXlTYf3mIMt3b0dDCOQFJiVvxbocJ5Ho577WiGPYPZcqVEO218L2iU22pDXzkTZCLDE+9AmGSUkWxeh/nZReA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.1.1.tgz",
+			"integrity": "sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==",
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"css-selector-tokenizer": "^0.7.0",
-				"icss-utils": "^2.1.0",
-				"loader-utils": "^1.0.2",
-				"lodash.camelcase": "^4.3.0",
-				"postcss": "^6.0.23",
-				"postcss-modules-extract-imports": "^1.2.0",
-				"postcss-modules-local-by-default": "^1.2.0",
-				"postcss-modules-scope": "^1.1.0",
-				"postcss-modules-values": "^1.3.0",
+				"camelcase": "^5.2.0",
+				"icss-utils": "^4.1.0",
+				"loader-utils": "^1.2.3",
+				"normalize-path": "^3.0.0",
+				"postcss": "^7.0.14",
+				"postcss-modules-extract-imports": "^2.0.0",
+				"postcss-modules-local-by-default": "^2.0.6",
+				"postcss-modules-scope": "^2.1.0",
+				"postcss-modules-values": "^2.0.0",
 				"postcss-value-parser": "^3.3.0",
-				"source-list-map": "^2.0.0"
+				"schema-utils": "^1.0.0"
+			},
+			"dependencies": {
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+				}
+			}
+		},
+		"css-prefers-color-scheme": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz",
+			"integrity": "sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==",
+			"requires": {
+				"postcss": "^7.0.5"
 			}
 		},
 		"css-select": {
@@ -2997,46 +3758,6 @@
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
 			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
 		},
-		"css-selector-tokenizer": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
-			"requires": {
-				"cssesc": "^0.1.0",
-				"fastparse": "^1.1.1",
-				"regexpu-core": "^1.0.0"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-				},
-				"regexpu-core": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-					"requires": {
-						"regenerate": "^1.2.1",
-						"regjsgen": "^0.2.0",
-						"regjsparser": "^0.1.4"
-					}
-				},
-				"regjsgen": {
-					"version": "0.2.0",
-					"resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-				},
-				"regjsparser": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-					"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-					"requires": {
-						"jsesc": "~0.5.0"
-					}
-				}
-			}
-		},
 		"css-tree": {
 			"version": "1.0.0-alpha.28",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
@@ -3044,13 +3765,6 @@
 			"requires": {
 				"mdn-data": "~1.1.0",
 				"source-map": "^0.5.3"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
 			}
 		},
 		"css-unit-converter": {
@@ -3064,90 +3778,66 @@
 			"integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w="
 		},
 		"css-what": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
-			"integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
 		},
 		"cssdb": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-3.2.1.tgz",
-			"integrity": "sha512-I0IS8zvxED8sQtFZnV7M+AkhWqTgp1HIyfMQJBbjdn4GgurBt7NCZaDgrWiAN2kNJN34mhF1p50aZIMQu290mA=="
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",
+			"integrity": "sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ=="
 		},
 		"cssesc": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
 		},
 		"cssnano": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.7.tgz",
-			"integrity": "sha512-AiXL90l+MDuQmRNyypG2P7ux7K4XklxYzNNUd5HXZCNcH8/N9bHPcpN97v8tXgRVeFL/Ed8iP8mVmAAu0ZpT7A==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
+			"integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
 			"requires": {
 				"cosmiconfig": "^5.0.0",
-				"cssnano-preset-default": "^4.0.5",
+				"cssnano-preset-default": "^4.0.7",
 				"is-resolvable": "^1.0.0",
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"cssnano-preset-default": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.5.tgz",
-			"integrity": "sha512-f1uhya0ZAjPYtDD58QkBB0R+uYdzHPei7cDxJyQQIHt5acdhyGXaSXl2nDLzWHLwGFbZcHxQtkJS8mmNwnxTvw==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
+			"integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
 			"requires": {
 				"css-declaration-sorter": "^4.0.1",
 				"cssnano-util-raw-cache": "^4.0.1",
 				"postcss": "^7.0.0",
-				"postcss-calc": "^7.0.0",
-				"postcss-colormin": "^4.0.2",
+				"postcss-calc": "^7.0.1",
+				"postcss-colormin": "^4.0.3",
 				"postcss-convert-values": "^4.0.1",
-				"postcss-discard-comments": "^4.0.1",
+				"postcss-discard-comments": "^4.0.2",
 				"postcss-discard-duplicates": "^4.0.2",
 				"postcss-discard-empty": "^4.0.1",
 				"postcss-discard-overridden": "^4.0.1",
-				"postcss-merge-longhand": "^4.0.9",
-				"postcss-merge-rules": "^4.0.2",
+				"postcss-merge-longhand": "^4.0.11",
+				"postcss-merge-rules": "^4.0.3",
 				"postcss-minify-font-values": "^4.0.2",
-				"postcss-minify-gradients": "^4.0.1",
-				"postcss-minify-params": "^4.0.1",
-				"postcss-minify-selectors": "^4.0.1",
+				"postcss-minify-gradients": "^4.0.2",
+				"postcss-minify-params": "^4.0.2",
+				"postcss-minify-selectors": "^4.0.2",
 				"postcss-normalize-charset": "^4.0.1",
-				"postcss-normalize-display-values": "^4.0.1",
-				"postcss-normalize-positions": "^4.0.1",
-				"postcss-normalize-repeat-style": "^4.0.1",
-				"postcss-normalize-string": "^4.0.1",
-				"postcss-normalize-timing-functions": "^4.0.1",
+				"postcss-normalize-display-values": "^4.0.2",
+				"postcss-normalize-positions": "^4.0.2",
+				"postcss-normalize-repeat-style": "^4.0.2",
+				"postcss-normalize-string": "^4.0.2",
+				"postcss-normalize-timing-functions": "^4.0.2",
 				"postcss-normalize-unicode": "^4.0.1",
 				"postcss-normalize-url": "^4.0.1",
-				"postcss-normalize-whitespace": "^4.0.1",
-				"postcss-ordered-values": "^4.1.1",
-				"postcss-reduce-initial": "^4.0.2",
-				"postcss-reduce-transforms": "^4.0.1",
-				"postcss-svgo": "^4.0.1",
+				"postcss-normalize-whitespace": "^4.0.2",
+				"postcss-ordered-values": "^4.1.2",
+				"postcss-reduce-initial": "^4.0.3",
+				"postcss-reduce-transforms": "^4.0.2",
+				"postcss-svgo": "^4.0.2",
 				"postcss-unique-selectors": "^4.0.1"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"cssnano-util-get-arguments": {
@@ -3166,18 +3856,6 @@
 			"integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"cssnano-util-same-parent": {
@@ -3201,23 +3879,18 @@
 						"mdn-data": "~1.1.0",
 						"source-map": "^0.5.3"
 					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
 		"cssom": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-			"integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog=="
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A=="
 		},
 		"cssstyle": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
-			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
+			"integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
 			"requires": {
 				"cssom": "0.3.x"
 			}
@@ -3228,9 +3901,9 @@
 			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
 		},
 		"damerau-levenshtein": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
-			"integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+			"integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA=="
 		},
 		"dashdash": {
 			"version": "1.14.1",
@@ -3248,6 +3921,18 @@
 				"abab": "^2.0.0",
 				"whatwg-mimetype": "^2.2.0",
 				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"whatwg-url": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
 			}
 		},
 		"date-now": {
@@ -3256,11 +3941,11 @@
 			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
 		},
 		"debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"requires": {
-				"ms": "2.0.0"
+				"ms": "^2.1.1"
 			}
 		},
 		"decamelize": {
@@ -3284,36 +3969,12 @@
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"default-gateway": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
-			"integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
+			"integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
 			"requires": {
-				"execa": "^0.10.0",
+				"execa": "^1.0.0",
 				"ip-regex": "^2.1.0"
-			},
-			"dependencies": {
-				"execa": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				}
-			}
-		},
-		"default-require-extensions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-			"requires": {
-				"strip-bom": "^2.0.0"
 			}
 		},
 		"define-properties": {
@@ -3367,17 +4028,37 @@
 			}
 		},
 		"del": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
 			"requires": {
-				"globby": "^5.0.0",
+				"globby": "^6.1.0",
 				"is-path-cwd": "^1.0.0",
 				"is-path-in-cwd": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
+				"p-map": "^1.1.1",
+				"pify": "^3.0.0",
 				"rimraf": "^2.2.8"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"requires": {
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+						}
+					}
+				}
 			}
 		},
 		"delayed-stream": {
@@ -3404,14 +4085,6 @@
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
-		"detect-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"requires": {
-				"repeating": "^2.0.0"
-			}
-		},
 		"detect-newline": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -3429,21 +4102,45 @@
 			"requires": {
 				"address": "^1.0.1",
 				"debug": "^2.6.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
-		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+		"diff-sequences": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+			"integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
-			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
 				"randombytes": "^2.0.0"
+			}
+		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"requires": {
+				"arrify": "^1.0.1",
+				"path-type": "^3.0.0"
 			}
 		},
 		"dns-equal": {
@@ -3469,9 +4166,9 @@
 			}
 		},
 		"doctrine": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"requires": {
 				"esutils": "^2.0.2"
 			}
@@ -3485,19 +4182,12 @@
 			}
 		},
 		"dom-serializer": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
 			"requires": {
-				"domelementtype": "~1.1.1",
-				"entities": "~1.1.1"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
-				}
+				"domelementtype": "^1.3.0",
+				"entities": "^1.1.1"
 			}
 		},
 		"domain-browser": {
@@ -3506,9 +4196,9 @@
 			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
 		},
 		"domelementtype": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
-			"integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
 		},
 		"domexception": {
 			"version": "1.0.1",
@@ -3519,9 +4209,9 @@
 			}
 		},
 		"domhandler": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
-			"integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
 			"requires": {
 				"domelementtype": "1"
 			}
@@ -3544,9 +4234,9 @@
 			}
 		},
 		"dotenv": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
-			"integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+			"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
 		},
 		"dotenv-expand": {
 			"version": "4.2.0",
@@ -3559,9 +4249,9 @@
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
 		"duplexify": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
 			"requires": {
 				"end-of-stream": "^1.0.0",
 				"inherits": "^2.0.1",
@@ -3584,9 +4274,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.82",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.82.tgz",
-			"integrity": "sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew=="
+			"version": "1.3.137",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+			"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw=="
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -3603,9 +4293,9 @@
 			}
 		},
 		"emoji-regex": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-			"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ=="
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
 		},
 		"emojis-list": {
 			"version": "2.1.0",
@@ -3665,15 +4355,16 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
 			"requires": {
-				"es-to-primitive": "^1.1.1",
+				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
 			}
 		},
 		"es-to-primitive": {
@@ -3697,9 +4388,9 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
 			"requires": {
 				"esprima": "^3.1.3",
 				"estraverse": "^4.2.0",
@@ -3712,118 +4403,85 @@
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
 					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"optional": true
 				}
 			}
 		},
 		"eslint": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.6.0.tgz",
-			"integrity": "sha512-/eVYs9VVVboX286mBK7bbKnO1yamUy2UCRjiY6MryhQL2PaaXCExsCQ2aO83OeYRhU2eCU/FMFP+tVMoOrzNrA==",
+			"version": "5.16.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+			"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"ajv": "^6.5.3",
+				"ajv": "^6.9.1",
 				"chalk": "^2.1.0",
 				"cross-spawn": "^6.0.5",
-				"debug": "^3.1.0",
-				"doctrine": "^2.1.0",
-				"eslint-scope": "^4.0.0",
+				"debug": "^4.0.1",
+				"doctrine": "^3.0.0",
+				"eslint-scope": "^4.0.3",
 				"eslint-utils": "^1.3.1",
 				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^4.0.0",
+				"espree": "^5.0.1",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
+				"file-entry-cache": "^5.0.1",
 				"functional-red-black-tree": "^1.0.1",
 				"glob": "^7.1.2",
 				"globals": "^11.7.0",
 				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^6.1.0",
-				"is-resolvable": "^1.1.0",
-				"js-yaml": "^3.12.0",
+				"inquirer": "^6.2.2",
+				"js-yaml": "^3.13.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.5",
+				"lodash": "^4.17.11",
 				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.8.2",
 				"path-is-inside": "^1.0.2",
-				"pluralize": "^7.0.0",
 				"progress": "^2.0.0",
-				"regexpp": "^2.0.0",
-				"require-uncached": "^1.0.3",
+				"regexpp": "^2.0.1",
 				"semver": "^5.5.1",
 				"strip-ansi": "^4.0.0",
 				"strip-json-comments": "^2.0.1",
-				"table": "^4.0.3",
+				"table": "^5.2.3",
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-					"integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"ansi-regex": {
+				"import-fresh": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+					"integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
 					"requires": {
-						"ms": "^2.1.1"
+						"parent-module": "^1.0.0",
+						"resolve-from": "^4.0.0"
 					}
 				},
-				"eslint-scope": {
+				"resolve-from": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-					"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
 				},
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-				},
-				"json-schema-traverse": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
 		"eslint-config-react-app": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-3.0.4.tgz",
-			"integrity": "sha512-Fos37wkB5QNc8Qh7HUq/ChMUi1njLE78Y2U0RD3MOtYRtPNrMyYw1pLufb8GwNSphMSgRgOkIdakc3d0yXbWyQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-4.0.1.tgz",
+			"integrity": "sha512-ZsaoXUIGsK8FCi/x4lT2bZR5mMkL/Kgj+Lnw690rbvvUr/uiwgFiD8FcfAhkCycm7Xte6O5lYz4EqMx2vX7jgw==",
 			"requires": {
-				"confusing-browser-globals": "^1.0.4"
+				"confusing-browser-globals": "^1.0.7"
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -3833,12 +4491,27 @@
 			"requires": {
 				"debug": "^2.6.9",
 				"resolve": "^1.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"eslint-loader": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.1.1.tgz",
-			"integrity": "sha512-1GrJFfSevQdYpoDzx8mEE2TDWsb/zmFuY09l6hURg1AeFIKQOvZ+vH0UPjzmd1CZIbfTV5HUkMeBmFiDBkgIsQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.1.2.tgz",
+			"integrity": "sha512-rA9XiXEOilLYPOIInvVH5S/hYfyTPyxag6DZhoQOduM+3TkghAEQ3VcFO8VnX4J4qg/UIBzp72aOf/xvYmpmsg==",
 			"requires": {
 				"loader-fs-cache": "^1.0.0",
 				"loader-utils": "^1.0.2",
@@ -3848,37 +4521,71 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
-			"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+			"integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
 			"requires": {
 				"debug": "^2.6.8",
-				"pkg-dir": "^1.0.0"
+				"pkg-dir": "^2.0.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"ms": "2.0.0"
 					}
 				},
-				"path-exists": {
+				"find-up": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"locate-path": "^2.0.0"
 					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 				},
 				"pkg-dir": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"requires": {
-						"find-up": "^1.0.0"
+						"find-up": "^2.1.0"
 					}
 				}
 			}
@@ -3892,22 +4599,30 @@
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
-			"integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
+			"integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
 			"requires": {
 				"contains-path": "^0.1.0",
-				"debug": "^2.6.8",
+				"debug": "^2.6.9",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "^0.3.1",
-				"eslint-module-utils": "^2.2.0",
-				"has": "^1.0.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.3",
+				"eslint-import-resolver-node": "^0.3.2",
+				"eslint-module-utils": "^2.3.0",
+				"has": "^1.0.3",
+				"lodash": "^4.17.11",
+				"minimatch": "^3.0.4",
 				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.6.0"
+				"resolve": "^1.9.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
 				"doctrine": {
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -3917,9 +4632,17 @@
 						"isarray": "^1.0.0"
 					}
 				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
 				"load-json-file": {
 					"version": "2.0.0",
-					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -3927,6 +4650,41 @@
 						"pify": "^2.0.0",
 						"strip-bom": "^3.0.0"
 					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 				},
 				"parse-json": {
 					"version": "2.2.0",
@@ -3943,6 +4701,11 @@
 					"requires": {
 						"pify": "^2.0.0"
 					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"read-pkg": {
 					"version": "2.0.0",
@@ -3962,45 +4725,57 @@
 						"find-up": "^2.0.0",
 						"read-pkg": "^2.0.0"
 					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				}
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.2.tgz",
-			"integrity": "sha512-7gSSmwb3A+fQwtw0arguwMdOdzmKUgnUcbSNlo+GjKLAQFuC2EZxWqG9XHRI8VscBJD5a8raz3RuxQNFW+XJbw==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+			"integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
 			"requires": {
 				"aria-query": "^3.0.0",
 				"array-includes": "^3.0.3",
 				"ast-types-flow": "^0.0.7",
-				"axobject-query": "^2.0.1",
+				"axobject-query": "^2.0.2",
 				"damerau-levenshtein": "^1.0.4",
-				"emoji-regex": "^6.5.1",
+				"emoji-regex": "^7.0.2",
 				"has": "^1.0.3",
 				"jsx-ast-utils": "^2.0.1"
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.11.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
-			"integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
+			"version": "7.12.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
+			"integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
 			"requires": {
 				"array-includes": "^3.0.3",
 				"doctrine": "^2.1.0",
 				"has": "^1.0.3",
 				"jsx-ast-utils": "^2.0.1",
-				"prop-types": "^15.6.2"
+				"object.fromentries": "^2.0.0",
+				"prop-types": "^15.6.2",
+				"resolve": "^1.9.0"
+			},
+			"dependencies": {
+				"doctrine": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"requires": {
+						"esutils": "^2.0.2"
+					}
+				}
 			}
 		},
+		"eslint-plugin-react-hooks": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz",
+			"integrity": "sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag=="
+		},
 		"eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+			"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
@@ -4017,20 +4792,13 @@
 			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
 		},
 		"espree": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-			"integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+			"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
 			"requires": {
-				"acorn": "^6.0.2",
+				"acorn": "^6.0.7",
 				"acorn-jsx": "^5.0.0",
 				"eslint-visitor-keys": "^1.0.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
-					"integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg=="
-				}
 			}
 		},
 		"esprima": {
@@ -4075,21 +4843,21 @@
 			"integrity": "sha512-y3mOpfy6wRemQGFXaAsbekG05d72/IK5sxQHNo/KGiYVYRtG0zER+fO2AAkqsL1KLTNqY7Da+GJWjzx0SHgIxg=="
 		},
 		"eventemitter3": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
 		},
 		"events": {
-			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
-			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
 		},
 		"eventsource": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+			"integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
 			"requires": {
-				"original": ">=0.0.5"
+				"original": "^1.0.0"
 			}
 		},
 		"evp_bytestokey": {
@@ -4102,37 +4870,22 @@
 			}
 		},
 		"exec-sh": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-			"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
-			"requires": {
-				"merge": "^1.2.0"
-			}
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+			"integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg=="
 		},
 		"execa": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
 				"is-stream": "^1.1.0",
 				"npm-run-path": "^2.0.0",
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				}
 			}
 		},
 		"exit": {
@@ -4141,75 +4894,96 @@
 			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
 		},
 		"expand-brackets": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
-			}
-		},
-		"expand-range": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"requires": {
-				"fill-range": "^2.1.0"
-			}
-		},
-		"expand-tilde": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-			"requires": {
-				"homedir-polyfill": "^1.0.1"
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"expect": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
-			"integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
+			"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
 			"requires": {
+				"@jest/types": "^24.8.0",
 				"ansi-styles": "^3.2.0",
-				"jest-diff": "^23.6.0",
-				"jest-get-type": "^22.1.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-regex-util": "^23.3.0"
+				"jest-get-type": "^24.8.0",
+				"jest-matcher-utils": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-regex-util": "^24.3.0"
 			}
 		},
 		"express": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
 			"requires": {
-				"accepts": "~1.3.5",
+				"accepts": "~1.3.7",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.18.3",
-				"content-disposition": "0.5.2",
+				"body-parser": "1.19.0",
+				"content-disposition": "0.5.3",
 				"content-type": "~1.0.4",
-				"cookie": "0.3.1",
+				"cookie": "0.4.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.1.1",
+				"finalhandler": "~1.1.2",
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
 				"methods": "~1.1.2",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
+				"parseurl": "~1.3.3",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.4",
-				"qs": "6.5.2",
-				"range-parser": "~1.2.0",
+				"proxy-addr": "~2.0.5",
+				"qs": "6.7.0",
+				"range-parser": "~1.2.1",
 				"safe-buffer": "5.1.2",
-				"send": "0.16.2",
-				"serve-static": "1.13.2",
-				"setprototypeof": "1.1.0",
-				"statuses": "~1.4.0",
-				"type-is": "~1.6.16",
+				"send": "0.17.1",
+				"serve-static": "1.14.1",
+				"setprototypeof": "1.1.1",
+				"statuses": "~1.5.0",
+				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
 			},
@@ -4218,6 +4992,24 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
 				}
 			}
 		},
@@ -4256,11 +5048,67 @@
 			}
 		},
 		"extglob": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
 			}
 		},
 		"extsprintf": {
@@ -4269,9 +5117,22 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+		},
+		"fast-glob": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+			"integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+			"requires": {
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.1.2",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.3",
+				"micromatch": "^3.1.10"
+			}
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -4282,11 +5143,6 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-		},
-		"fastparse": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
 		},
 		"faye-websocket": {
 			"version": "0.11.1",
@@ -4339,35 +5195,20 @@
 			}
 		},
 		"file-entry-cache": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
 			"requires": {
-				"flat-cache": "^1.2.1",
-				"object-assign": "^4.0.1"
+				"flat-cache": "^2.0.1"
 			}
 		},
 		"file-loader": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
-			"integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
+			"integrity": "sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==",
 			"requires": {
 				"loader-utils": "^1.0.2",
 				"schema-utils": "^1.0.0"
-			}
-		},
-		"filename-regex": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-		},
-		"fileset": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
-			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-			"requires": {
-				"glob": "^7.0.3",
-				"minimatch": "^3.0.3"
 			}
 		},
 		"filesize": {
@@ -4376,69 +5217,87 @@
 			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
 		},
 		"fill-range": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^3.0.0",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
 			},
 			"dependencies": {
-				"isobject": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"isarray": "1.0.0"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
 		},
 		"finalhandler": {
-			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
 			"requires": {
 				"debug": "2.6.9",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.4.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
 				"unpipe": "~1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"find-cache-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+			"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
 			"requires": {
 				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
-				"pkg-dir": "^2.0.0"
+				"make-dir": "^2.0.0",
+				"pkg-dir": "^3.0.0"
 			}
 		},
 		"find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "^3.0.0"
 			}
 		},
 		"flat-cache": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
 			"requires": {
-				"circular-json": "^0.3.1",
-				"del": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"write": "^0.2.1"
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
 			}
+		},
+		"flatted": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+			"integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg=="
 		},
 		"flatten": {
 			"version": "1.0.2",
@@ -4446,28 +5305,28 @@
 			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
 		},
 		"flush-write-stream": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.4"
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.3.6"
 			}
 		},
 		"follow-redirects": {
-			"version": "1.5.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
-			"integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+			"integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
 			"requires": {
-				"debug": "=3.1.0"
+				"debug": "^3.2.6"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
 				}
 			}
@@ -4489,6 +5348,28 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"fork-ts-checker-webpack-plugin": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.1.1.tgz",
+			"integrity": "sha512-gqWAEMLlae/oeVnN6RWCAhesOJMswAN1MaKNqhhjXHV5O0/rTUjWI4UbgQHdlrVbCnb+xLotXmJbBlC66QmpFw==",
+			"requires": {
+				"babel-code-frame": "^6.22.0",
+				"chalk": "^2.4.1",
+				"chokidar": "^2.0.4",
+				"micromatch": "^3.1.10",
+				"minimatch": "^3.0.4",
+				"semver": "^5.6.0",
+				"tapable": "^1.0.0",
+				"worker-rpc": "^0.1.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
+			}
 		},
 		"form-data": {
 			"version": "2.3.3",
@@ -4528,9 +5409,9 @@
 			}
 		},
 		"fs-extra": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-			"integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
@@ -4554,485 +5435,10 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-			"optional": true,
-			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"bundled": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"debug": {
-					"version": "2.6.9",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"deep-extend": {
-					"version": "0.5.1",
-					"bundled": true,
-					"optional": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"bundled": true,
-					"optional": true
-				},
-				"fs-minipass": {
-					"version": "1.2.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"iconv-lite": {
-					"version": "0.4.21",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safer-buffer": "^2.1.0"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true,
-					"optional": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true,
-					"optional": true
-				},
-				"minipass": {
-					"version": "2.2.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.1.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"needle": {
-					"version": "2.2.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.10.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.3",
-					"bundled": true,
-					"optional": true
-				},
-				"npm-packlist": {
-					"version": "1.1.10",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.7",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "^0.5.1",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"glob": "^7.0.5"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true,
-					"optional": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true,
-					"optional": true
-				},
-				"semver": {
-					"version": "5.5.0",
-					"bundled": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "4.4.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"chownr": "^1.0.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.2"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"wide-align": {
-					"version": "1.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"string-width": "^1.0.2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"yallist": {
-					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
-				}
-			}
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.6.tgz",
+			"integrity": "sha512-vfmKZp3XPM36DNF0qhW+Cdxk7xm7gTEHY1clv1Xq1arwRQuKZgAhw+NZNWbJBtuaNxzNXwhfdPYRrvIbjfS33A==",
+			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -5055,9 +5461,12 @@
 			"integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
 		},
 		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"requires": {
+				"pump": "^3.0.0"
+			}
 		},
 		"get-value": {
 			"version": "2.0.6",
@@ -5085,9 +5494,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -5097,67 +5506,90 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
 			}
 		},
-		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"requires": {
-				"is-glob": "^2.0.0"
-			}
+		"glob-to-regexp": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
 		},
 		"global-modules": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
 			"requires": {
-				"global-prefix": "^1.0.1",
-				"is-windows": "^1.0.1",
-				"resolve-dir": "^1.0.0"
+				"global-prefix": "^3.0.0"
 			}
 		},
 		"global-prefix": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
 			"requires": {
-				"expand-tilde": "^2.0.2",
-				"homedir-polyfill": "^1.0.1",
-				"ini": "^1.3.4",
-				"is-windows": "^1.0.1",
-				"which": "^1.2.14"
+				"ini": "^1.3.5",
+				"kind-of": "^6.0.2",
+				"which": "^1.3.1"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
 			}
 		},
 		"globals": {
-			"version": "11.8.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-			"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 		},
 		"globby": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+			"integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
 			"requires": {
 				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"dir-glob": "2.0.0",
+				"fast-glob": "^2.0.2",
+				"glob": "^7.1.2",
+				"ignore": "^3.3.5",
+				"pify": "^3.0.0",
+				"slash": "^1.0.0"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "3.3.10",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+					"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				}
 			}
 		},
 		"graceful-fs": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -5171,77 +5603,29 @@
 			"requires": {
 				"duplexer": "^0.1.1",
 				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				}
 			}
-		},
-		"h2x-core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/h2x-core/-/h2x-core-1.1.1.tgz",
-			"integrity": "sha512-LdXe4Irs731knLtHgLyFrnJCumfiqXXQwKN1IMUhi37li29PLfLbMDvfK7Rk4wmgHLKP+sIITT1mcJV4QsC3nw==",
-			"requires": {
-				"h2x-generate": "^1.1.0",
-				"h2x-parse": "^1.1.1",
-				"h2x-traverse": "^1.1.0"
-			}
-		},
-		"h2x-generate": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/h2x-generate/-/h2x-generate-1.1.0.tgz",
-			"integrity": "sha512-L7Hym0yb20QIjvqeULUPOeh/cyvScdOAyJ6oRlh5dF0+w92hf3OiTk1q15KBijde7jGEe+0R4aOmtW8gkPNIzg==",
-			"requires": {
-				"h2x-traverse": "^1.1.0"
-			}
-		},
-		"h2x-parse": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/h2x-parse/-/h2x-parse-1.1.1.tgz",
-			"integrity": "sha512-WRSmPF+tIWuUXVEZaYRhcZx/JGEJx8LjZpDDtrvMr5m/GTR0NerydCik5dRzcKXPWCtfXxuJRLR4v2P4HB2B1A==",
-			"requires": {
-				"h2x-types": "^1.1.0",
-				"jsdom": ">=11.0.0"
-			}
-		},
-		"h2x-plugin-jsx": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/h2x-plugin-jsx/-/h2x-plugin-jsx-1.2.0.tgz",
-			"integrity": "sha512-a7Vb3BHhJJq0dPDNdqguEyQirENkVsFtvM2YkiaT5h/fmGhmM1nDy3BLeJeSKi2tL2g9v4ykm2Z+GG9QrhDgPA==",
-			"requires": {
-				"h2x-types": "^1.1.0"
-			}
-		},
-		"h2x-traverse": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/h2x-traverse/-/h2x-traverse-1.1.0.tgz",
-			"integrity": "sha512-1ND8ZbISLSUgpLHYJRvhvElITvs0g44L7RxjeXViz5XP6rooa+FtXTFLByl2Yg01zj2txubifHIuU4pgvj8l+A==",
-			"requires": {
-				"h2x-types": "^1.1.0"
-			}
-		},
-		"h2x-types": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/h2x-types/-/h2x-types-1.1.0.tgz",
-			"integrity": "sha512-QdH5qfLcdF209UsCdM0ZNZ9Dwm2PHvMfeLZtivBrjX3Y/df4US2pwsUC4HBfWhye/mx/t6puODeC7Oacb/Ol8g=="
 		},
 		"handle-thing": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+			"integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
 		},
 		"handlebars": {
-			"version": "4.0.12",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
 			"requires": {
-				"async": "^2.5.0",
+				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
 				"source-map": "^0.6.1",
 				"uglify-js": "^3.1.4"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"har-schema": {
@@ -5250,11 +5634,11 @@
 			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"requires": {
-				"ajv": "^5.3.0",
+				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
 			}
 		},
@@ -5277,6 +5661,13 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
 				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				}
 			}
 		},
 		"has-flag": {
@@ -5308,23 +5699,10 @@
 				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 				},
 				"kind-of": {
 					"version": "4.0.0",
@@ -5346,12 +5724,40 @@
 			}
 		},
 		"hash.js": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
-			"integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"hast-util-from-parse5": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.1.tgz",
+			"integrity": "sha512-UfPzdl6fbxGAxqGYNThRUhRlDYY7sXu6XU9nQeX4fFZtV+IHbyEJtd+DUuwOqNV4z3K05E/1rIkoVr/JHmeWWA==",
+			"requires": {
+				"ccount": "^1.0.3",
+				"hastscript": "^5.0.0",
+				"property-information": "^5.0.0",
+				"web-namespaces": "^1.1.2",
+				"xtend": "^4.0.1"
+			}
+		},
+		"hast-util-parse-selector": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.2.tgz",
+			"integrity": "sha512-jIMtnzrLTjzqgVEQqPEmwEZV+ea4zHRFTP8Z2Utw0I5HuBOXHzUPPQWr6ouJdJqDKLbFU/OEiYwZ79LalZkmmw=="
+		},
+		"hastscript": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.0.1.tgz",
+			"integrity": "sha512-i9nc9NRtVIKlvVfVJ/Tnonk5PXO3BOqaqwfxHw53CWZEETpLCFIjvu0jej/DzT/xlXFOVDpB7KRUFpUrgU8Tow==",
+			"requires": {
+				"comma-separated-tokens": "^1.0.0",
+				"hast-util-parse-selector": "^2.2.0",
+				"property-information": "^5.0.1",
+				"space-separated-tokens": "^1.0.0"
 			}
 		},
 		"he": {
@@ -5373,33 +5779,6 @@
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
-		},
-		"hoek": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-		},
-		"home-or-tmp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
-			}
-		},
-		"homedir-polyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-			"requires": {
-				"parse-passwd": "^1.0.0"
-			}
-		},
-		"hoopy": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
-			"integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
 		},
 		"hosted-git-info": {
 			"version": "2.7.1",
@@ -5457,61 +5836,50 @@
 				"param-case": "2.1.x",
 				"relateurl": "0.2.x",
 				"uglify-js": "3.4.x"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+				}
 			}
 		},
 		"html-webpack-plugin": {
-			"version": "4.0.0-alpha.2",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-alpha.2.tgz",
-			"integrity": "sha512-tyvhjVpuGqD7QYHi1l1drMQTg5i+qRxpQEGbdnYFREgOKy7aFDf/ocQ/V1fuEDlQx7jV2zMap3Hj2nE9i5eGXw==",
+			"version": "4.0.0-beta.5",
+			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.5.tgz",
+			"integrity": "sha512-y5l4lGxOW3pz3xBTFdfB9rnnrWRPVxlAhX6nrBYIcW+2k2zC3mSp/3DxlWVCMBfnO6UAnoF8OcFn0IMy6kaKAQ==",
 			"requires": {
-				"@types/tapable": "1.0.2",
-				"html-minifier": "^3.2.3",
+				"html-minifier": "^3.5.20",
 				"loader-utils": "^1.1.0",
-				"lodash": "^4.17.10",
-				"pretty-error": "^2.0.2",
-				"tapable": "^1.0.0",
+				"lodash": "^4.17.11",
+				"pretty-error": "^2.1.1",
+				"tapable": "^1.1.0",
 				"util.promisify": "1.0.0"
 			}
 		},
 		"htmlparser2": {
-			"version": "3.3.0",
-			"resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
-			"integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
 			"requires": {
-				"domelementtype": "1",
-				"domhandler": "2.1",
-				"domutils": "1.1",
-				"readable-stream": "1.0"
+				"domelementtype": "^1.3.1",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^3.1.1"
 			},
 			"dependencies": {
-				"domutils": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
-					"integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-					"requires": {
-						"domelementtype": "1"
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
 				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -5521,14 +5889,15 @@
 			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
 		},
 		"http-errors": {
-			"version": "1.6.3",
-			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
 			"requires": {
 				"depd": "~1.1.2",
 				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"setprototypeof": "1.1.1",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.0"
 			}
 		},
 		"http-parser-js": {
@@ -5547,272 +5916,14 @@
 			}
 		},
 		"http-proxy-middleware": {
-			"version": "0.18.0",
-			"resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
-			"integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+			"integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
 			"requires": {
-				"http-proxy": "^1.16.2",
+				"http-proxy": "^1.17.0",
 				"is-glob": "^4.0.0",
-				"lodash": "^4.17.5",
-				"micromatch": "^3.1.9"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-				},
-				"is-glob": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				}
+				"lodash": "^4.17.11",
+				"micromatch": "^3.1.10"
 			}
 		},
 		"http-signature": {
@@ -5849,11 +5960,11 @@
 			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
 		},
 		"icss-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
-			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.0.tgz",
+			"integrity": "sha512-3DEun4VOeMvSczifM3F2cKQrDQ5Pj6WKhkOq6HD4QTnDUAq8MQRxy5TX6Sy1iY6WPBe4gQ3p5vTECjbIkglkkQ==",
 			"requires": {
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.14"
 			}
 		},
 		"identity-obj-proxy": {
@@ -5865,9 +5976,9 @@
 			}
 		},
 		"ieee754": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -5879,6 +5990,11 @@
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
 		},
+		"immer": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
+			"integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg=="
+		},
 		"import-cwd": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -5887,27 +6003,29 @@
 				"import-from": "^2.1.0"
 			}
 		},
+		"import-fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+			"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+			"requires": {
+				"caller-path": "^2.0.0",
+				"resolve-from": "^3.0.0"
+			}
+		},
 		"import-from": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
 			"integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
 			"requires": {
 				"resolve-from": "^3.0.0"
-			},
-			"dependencies": {
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-				}
 			}
 		},
 		"import-local": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
 			"requires": {
-				"pkg-dir": "^2.0.0",
+				"pkg-dir": "^3.0.0",
 				"resolve-cwd": "^2.0.0"
 			}
 		},
@@ -5955,47 +6073,47 @@
 			}
 		},
 		"inquirer": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-			"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+			"integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
+				"ansi-escapes": "^3.2.0",
+				"chalk": "^2.4.2",
 				"cli-cursor": "^2.1.0",
 				"cli-width": "^2.0.0",
-				"external-editor": "^3.0.0",
+				"external-editor": "^3.0.3",
 				"figures": "^2.0.0",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.11",
 				"mute-stream": "0.0.7",
 				"run-async": "^2.2.0",
-				"rxjs": "^6.1.0",
+				"rxjs": "^6.4.0",
 				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
+				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^4.1.0"
 					}
 				}
 			}
 		},
 		"internal-ip": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
-			"integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
+			"integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
 			"requires": {
-				"default-gateway": "^2.6.0",
-				"ipaddr.js": "^1.5.2"
+				"default-gateway": "^4.2.0",
+				"ipaddr.js": "^1.9.0"
 			}
 		},
 		"invariant": {
@@ -6007,9 +6125,9 @@
 			}
 		},
 		"invert-kv": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
 		},
 		"ip": {
 			"version": "1.1.5",
@@ -6022,9 +6140,9 @@
 			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
 		},
 		"ipaddr.js": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
 		},
 		"is-absolute-url": {
 			"version": "2.1.0",
@@ -6053,17 +6171,9 @@
 			}
 		},
 		"is-buffer": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-		},
-		"is-builtin-module": {
-			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"requires": {
-				"builtin-modules": "^1.0.0"
-			}
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+			"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
 		},
 		"is-callable": {
 			"version": "1.1.4",
@@ -6071,11 +6181,11 @@
 			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
 		},
 		"is-ci": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
 			"requires": {
-				"ci-info": "^1.5.0"
+				"ci-info": "^2.0.0"
 			}
 		},
 		"is-color-stop": {
@@ -6126,36 +6236,15 @@
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
 			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
 		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-		},
-		"is-equal-shallow": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"requires": {
-				"is-primitive": "^2.0.0"
-			}
-		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-		},
-		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
@@ -6163,29 +6252,29 @@
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-generator-fn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
 		},
 		"is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "^2.1.1"
 			}
 		},
 		"is-number": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
 		"is-path-cwd": {
@@ -6209,6 +6298,11 @@
 				"path-is-inside": "^1.0.1"
 			}
 		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -6216,16 +6310,6 @@
 			"requires": {
 				"isobject": "^3.0.1"
 			}
-		},
-		"is-posix-bracket": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-		},
-		"is-primitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-promise": {
 			"version": "2.1.0",
@@ -6281,11 +6365,6 @@
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -6300,14 +6379,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-		},
-		"isemail": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-			"integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-			"requires": {
-				"punycode": "2.x.x"
-			}
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -6333,326 +6404,242 @@
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
-		"istanbul-api": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
-			"integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
-			"requires": {
-				"async": "^2.1.4",
-				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.2.1",
-				"istanbul-lib-hook": "^1.2.2",
-				"istanbul-lib-instrument": "^1.10.2",
-				"istanbul-lib-report": "^1.1.5",
-				"istanbul-lib-source-maps": "^1.2.6",
-				"istanbul-reports": "^1.5.1",
-				"js-yaml": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"once": "^1.4.0"
-			}
-		},
 		"istanbul-lib-coverage": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-			"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ=="
-		},
-		"istanbul-lib-hook": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
-			"integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
-			"requires": {
-				"append-transform": "^0.4.0"
-			}
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+			"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA=="
 		},
 		"istanbul-lib-instrument": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
-			"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+			"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
 			"requires": {
-				"babel-generator": "^6.18.0",
-				"babel-template": "^6.16.0",
-				"babel-traverse": "^6.18.0",
-				"babel-types": "^6.18.0",
-				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.2.1",
-				"semver": "^5.3.0"
+				"@babel/generator": "^7.4.0",
+				"@babel/parser": "^7.4.3",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.3",
+				"@babel/types": "^7.4.0",
+				"istanbul-lib-coverage": "^2.0.5",
+				"semver": "^6.0.0"
 			}
 		},
 		"istanbul-lib-report": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
-			"integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+			"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
 			"requires": {
-				"istanbul-lib-coverage": "^1.2.1",
-				"mkdirp": "^0.5.1",
-				"path-parse": "^1.0.5",
-				"supports-color": "^3.1.2"
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
-			"integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+			"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
 			"requires": {
-				"debug": "^3.1.0",
-				"istanbul-lib-coverage": "^1.2.1",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.6.1",
-				"source-map": "^0.5.3"
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"rimraf": "^2.6.3",
+				"source-map": "^0.6.1"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"istanbul-reports": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
-			"integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+			"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
 			"requires": {
-				"handlebars": "^4.0.3"
+				"handlebars": "^4.1.2"
 			}
 		},
 		"jest": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
-			"integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
+			"version": "24.7.1",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.7.1.tgz",
+			"integrity": "sha512-AbvRar5r++izmqo5gdbAjTeA6uNRGoNRuj5vHB0OnDXo2DXWZJVuaObiGgtlvhKb+cWy2oYbQSfxv7Q7GjnAtA==",
 			"requires": {
-				"import-local": "^1.0.0",
-				"jest-cli": "^23.6.0"
+				"import-local": "^2.0.0",
+				"jest-cli": "^24.7.1"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
 				"jest-cli": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
-					"integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz",
+					"integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
 					"requires": {
-						"ansi-escapes": "^3.0.0",
+						"@jest/core": "^24.8.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.0.1",
 						"exit": "^0.1.2",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"import-local": "^1.0.0",
-						"is-ci": "^1.0.10",
-						"istanbul-api": "^1.3.1",
-						"istanbul-lib-coverage": "^1.2.0",
-						"istanbul-lib-instrument": "^1.10.1",
-						"istanbul-lib-source-maps": "^1.2.4",
-						"jest-changed-files": "^23.4.2",
-						"jest-config": "^23.6.0",
-						"jest-environment-jsdom": "^23.4.0",
-						"jest-get-type": "^22.1.0",
-						"jest-haste-map": "^23.6.0",
-						"jest-message-util": "^23.4.0",
-						"jest-regex-util": "^23.3.0",
-						"jest-resolve-dependencies": "^23.6.0",
-						"jest-runner": "^23.6.0",
-						"jest-runtime": "^23.6.0",
-						"jest-snapshot": "^23.6.0",
-						"jest-util": "^23.4.0",
-						"jest-validate": "^23.6.0",
-						"jest-watcher": "^23.4.0",
-						"jest-worker": "^23.2.0",
-						"micromatch": "^2.3.11",
-						"node-notifier": "^5.2.1",
-						"prompts": "^0.1.9",
-						"realpath-native": "^1.0.0",
-						"rimraf": "^2.5.4",
-						"slash": "^1.0.0",
-						"string-length": "^2.0.0",
-						"strip-ansi": "^4.0.0",
-						"which": "^1.2.12",
-						"yargs": "^11.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
+						"import-local": "^2.0.0",
+						"is-ci": "^2.0.0",
+						"jest-config": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
+						"prompts": "^2.0.1",
+						"realpath-native": "^1.1.0",
+						"yargs": "^12.0.2"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
-			"integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
+			"integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
 			"requires": {
+				"@jest/types": "^24.8.0",
+				"execa": "^1.0.0",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
-			"integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
+			"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-jest": "^23.6.0",
+				"@babel/core": "^7.1.0",
+				"@jest/test-sequencer": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"babel-jest": "^24.8.0",
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^23.4.0",
-				"jest-environment-node": "^23.4.0",
-				"jest-get-type": "^22.1.0",
-				"jest-jasmine2": "^23.6.0",
-				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-validate": "^23.6.0",
-				"micromatch": "^2.3.11",
-				"pretty-format": "^23.6.0"
+				"jest-environment-jsdom": "^24.8.0",
+				"jest-environment-node": "^24.8.0",
+				"jest-get-type": "^24.8.0",
+				"jest-jasmine2": "^24.8.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-validate": "^24.8.0",
+				"micromatch": "^3.1.10",
+				"pretty-format": "^24.8.0",
+				"realpath-native": "^1.1.0"
 			},
 			"dependencies": {
-				"babel-core": {
-					"version": "6.26.3",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+				"jest-resolve": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+					"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
 					"requires": {
-						"babel-code-frame": "^6.26.0",
-						"babel-generator": "^6.26.0",
-						"babel-helpers": "^6.24.1",
-						"babel-messages": "^6.23.0",
-						"babel-register": "^6.26.0",
-						"babel-runtime": "^6.26.0",
-						"babel-template": "^6.26.0",
-						"babel-traverse": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"convert-source-map": "^1.5.1",
-						"debug": "^2.6.9",
-						"json5": "^0.5.1",
-						"lodash": "^4.17.4",
-						"minimatch": "^3.0.4",
-						"path-is-absolute": "^1.0.1",
-						"private": "^0.1.8",
-						"slash": "^1.0.0",
-						"source-map": "^0.5.7"
+						"@jest/types": "^24.8.0",
+						"browser-resolve": "^1.11.3",
+						"chalk": "^2.0.1",
+						"jest-pnp-resolver": "^1.2.1",
+						"realpath-native": "^1.1.0"
 					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
 		"jest-diff": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
-			"integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+			"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
 			"requires": {
 				"chalk": "^2.0.1",
-				"diff": "^3.2.0",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.6.0"
+				"diff-sequences": "^24.3.0",
+				"jest-get-type": "^24.8.0",
+				"pretty-format": "^24.8.0"
 			}
 		},
 		"jest-docblock": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
-			"integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+			"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
 			"requires": {
 				"detect-newline": "^2.1.0"
 			}
 		},
 		"jest-each": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
-			"integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
+			"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
 			"requires": {
+				"@jest/types": "^24.8.0",
 				"chalk": "^2.0.1",
-				"pretty-format": "^23.6.0"
+				"jest-get-type": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"pretty-format": "^24.8.0"
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
-			"integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
+			"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
 			"requires": {
-				"jest-mock": "^23.2.0",
-				"jest-util": "^23.4.0",
+				"@jest/environment": "^24.8.0",
+				"@jest/fake-timers": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"jest-mock": "^24.8.0",
+				"jest-util": "^24.8.0",
 				"jsdom": "^11.5.1"
+			}
+		},
+		"jest-environment-jsdom-fourteen": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom-fourteen/-/jest-environment-jsdom-fourteen-0.1.0.tgz",
+			"integrity": "sha512-4vtoRMg7jAstitRzL4nbw83VmGH8Rs13wrND3Ud2o1fczDhMUF32iIrNKwYGgeOPUdfvZU4oy8Bbv+ni1fgVCA==",
+			"requires": {
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jsdom": "^14.0.0"
 			},
 			"dependencies": {
 				"jsdom": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
-					"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+					"version": "14.1.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-14.1.0.tgz",
+					"integrity": "sha512-O901mfJSuTdwU2w3Sn+74T+RnDVP+FuV5fH8tcPWyqrseRAb0s5xOtPgCFiPOtLcyK7CLIJwPyD83ZqQWvA5ng==",
 					"requires": {
 						"abab": "^2.0.0",
-						"acorn": "^5.5.3",
-						"acorn-globals": "^4.1.0",
+						"acorn": "^6.0.4",
+						"acorn-globals": "^4.3.0",
 						"array-equal": "^1.0.0",
-						"cssom": ">= 0.3.2 < 0.4.0",
-						"cssstyle": "^1.0.0",
-						"data-urls": "^1.0.0",
+						"cssom": "^0.3.4",
+						"cssstyle": "^1.1.1",
+						"data-urls": "^1.1.0",
 						"domexception": "^1.0.1",
-						"escodegen": "^1.9.1",
+						"escodegen": "^1.11.0",
 						"html-encoding-sniffer": "^1.0.2",
-						"left-pad": "^1.3.0",
-						"nwsapi": "^2.0.7",
-						"parse5": "4.0.0",
+						"nwsapi": "^2.1.3",
+						"parse5": "5.1.0",
 						"pn": "^1.1.0",
-						"request": "^2.87.0",
+						"request": "^2.88.0",
 						"request-promise-native": "^1.0.5",
-						"sax": "^1.2.4",
+						"saxes": "^3.1.9",
 						"symbol-tree": "^3.2.2",
-						"tough-cookie": "^2.3.4",
+						"tough-cookie": "^2.5.0",
 						"w3c-hr-time": "^1.0.1",
+						"w3c-xmlserializer": "^1.1.2",
 						"webidl-conversions": "^4.0.2",
-						"whatwg-encoding": "^1.0.3",
-						"whatwg-mimetype": "^2.1.0",
-						"whatwg-url": "^6.4.1",
-						"ws": "^5.2.0",
+						"whatwg-encoding": "^1.0.5",
+						"whatwg-mimetype": "^2.3.0",
+						"whatwg-url": "^7.0.0",
+						"ws": "^6.1.2",
 						"xml-name-validator": "^3.0.0"
 					}
 				},
-				"parse5": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
-				},
 				"whatwg-url": {
-					"version": "6.5.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-					"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
 					"requires": {
 						"lodash.sortby": "^4.7.0",
 						"tr46": "^1.0.1",
@@ -6660,9 +6647,9 @@
 					}
 				},
 				"ws": {
-					"version": "5.2.2",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-					"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
 					"requires": {
 						"async-limiter": "~1.0.0"
 					}
@@ -6670,301 +6657,857 @@
 			}
 		},
 		"jest-environment-node": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
-			"integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
+			"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
 			"requires": {
-				"jest-mock": "^23.2.0",
-				"jest-util": "^23.4.0"
+				"@jest/environment": "^24.8.0",
+				"@jest/fake-timers": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"jest-mock": "^24.8.0",
+				"jest-util": "^24.8.0"
 			}
 		},
 		"jest-get-type": {
-			"version": "22.4.3",
-			"resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+			"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ=="
 		},
 		"jest-haste-map": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
-			"integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
+			"integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
 			"requires": {
+				"@jest/types": "^24.8.0",
+				"anymatch": "^2.0.0",
 				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.1.11",
+				"fsevents": "^1.2.7",
+				"graceful-fs": "^4.1.15",
 				"invariant": "^2.2.4",
-				"jest-docblock": "^23.2.0",
-				"jest-serializer": "^23.0.1",
-				"jest-worker": "^23.2.0",
-				"micromatch": "^2.3.11",
-				"sane": "^2.0.0"
+				"jest-serializer": "^24.4.0",
+				"jest-util": "^24.8.0",
+				"jest-worker": "^24.6.0",
+				"micromatch": "^3.1.10",
+				"sane": "^4.0.3",
+				"walker": "^1.0.7"
+			},
+			"dependencies": {
+				"fsevents": {
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+					"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+					"optional": true,
+					"requires": {
+						"nan": "^2.12.1",
+						"node-pre-gyp": "^0.12.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"optional": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"optional": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "4.1.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"deep-extend": {
+							"version": "0.6.0",
+							"bundled": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.24",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"optional": true
+						},
+						"minipass": {
+							"version": "2.3.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.2.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.3.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"debug": "^4.1.0",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.12.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.1",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.2.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.6",
+							"bundled": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.4.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.8",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.6.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.7.0",
+							"bundled": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.8",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.3.4",
+								"minizlib": "^1.1.1",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2 || 2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"yallist": {
+							"version": "3.0.3",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				}
 			}
 		},
 		"jest-jasmine2": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
-			"integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
+			"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
 			"requires": {
-				"babel-traverse": "^6.0.0",
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^24.8.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/types": "^24.8.0",
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
-				"expect": "^23.6.0",
-				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^23.6.0",
-				"jest-each": "^23.6.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-snapshot": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"pretty-format": "^23.6.0"
+				"expect": "^24.8.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^24.8.0",
+				"jest-matcher-utils": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-runtime": "^24.8.0",
+				"jest-snapshot": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"pretty-format": "^24.8.0",
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-leak-detector": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
-			"integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
+			"integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
 			"requires": {
-				"pretty-format": "^23.6.0"
+				"pretty-format": "^24.8.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
-			"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+			"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
 			"requires": {
 				"chalk": "^2.0.1",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.6.0"
+				"jest-diff": "^24.8.0",
+				"jest-get-type": "^24.8.0",
+				"pretty-format": "^24.8.0"
 			}
 		},
 		"jest-message-util": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
-			"integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+			"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
 			"requires": {
-				"@babel/code-frame": "^7.0.0-beta.35",
+				"@babel/code-frame": "^7.0.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"@types/stack-utils": "^1.0.1",
 				"chalk": "^2.0.1",
-				"micromatch": "^2.3.11",
-				"slash": "^1.0.0",
+				"micromatch": "^3.1.10",
+				"slash": "^2.0.0",
 				"stack-utils": "^1.0.1"
 			}
 		},
 		"jest-mock": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
-			"integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ="
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+			"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
+			"requires": {
+				"@jest/types": "^24.8.0"
+			}
 		},
 		"jest-pnp-resolver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.0.1.tgz",
-			"integrity": "sha512-kzhvJQp+9k0a/hpvIIzOJgOwfOqmnohdrAMZW2EscH3kxR2VWD7EcPa10cio8EK9V7PcD75bhG1pFnO70zGwSQ=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ=="
 		},
 		"jest-regex-util": {
-			"version": "23.3.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
-			"integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U="
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+			"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg=="
 		},
 		"jest-resolve": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
-			"integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
+			"version": "24.7.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.7.1.tgz",
+			"integrity": "sha512-Bgrc+/UUZpGJ4323sQyj85hV9d+ANyPNu6XfRDUcyFNX1QrZpSoM0kE4Mb2vZMAYTJZsBFzYe8X1UaOkOELSbw==",
 			"requires": {
+				"@jest/types": "^24.7.0",
 				"browser-resolve": "^1.11.3",
 				"chalk": "^2.0.1",
-				"realpath-native": "^1.0.0"
+				"jest-pnp-resolver": "^1.2.1",
+				"realpath-native": "^1.1.0"
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
-			"integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
+			"integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
 			"requires": {
-				"jest-regex-util": "^23.3.0",
-				"jest-snapshot": "^23.6.0"
+				"@jest/types": "^24.8.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-snapshot": "^24.8.0"
 			}
 		},
 		"jest-runner": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
-			"integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
+			"integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
 			"requires": {
+				"@jest/console": "^24.7.1",
+				"@jest/environment": "^24.8.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"chalk": "^2.4.2",
 				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.6.0",
-				"jest-docblock": "^23.2.0",
-				"jest-haste-map": "^23.6.0",
-				"jest-jasmine2": "^23.6.0",
-				"jest-leak-detector": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-runtime": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-worker": "^23.2.0",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.8.0",
+				"jest-docblock": "^24.3.0",
+				"jest-haste-map": "^24.8.0",
+				"jest-jasmine2": "^24.8.0",
+				"jest-leak-detector": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-resolve": "^24.8.0",
+				"jest-runtime": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-worker": "^24.6.0",
 				"source-map-support": "^0.5.6",
 				"throat": "^4.0.0"
 			},
 			"dependencies": {
-				"source-map-support": {
-					"version": "0.5.9",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+				"jest-resolve": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+					"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
 					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
+						"@jest/types": "^24.8.0",
+						"browser-resolve": "^1.11.3",
+						"chalk": "^2.0.1",
+						"jest-pnp-resolver": "^1.2.1",
+						"realpath-native": "^1.1.0"
 					}
 				}
 			}
 		},
 		"jest-runtime": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
-			"integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
+			"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-plugin-istanbul": "^4.1.6",
+				"@jest/console": "^24.7.1",
+				"@jest/environment": "^24.8.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"@types/yargs": "^12.0.2",
 				"chalk": "^2.0.1",
-				"convert-source-map": "^1.4.0",
 				"exit": "^0.1.2",
-				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.6.0",
-				"jest-haste-map": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.6.0",
-				"jest-snapshot": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-validate": "^23.6.0",
-				"micromatch": "^2.3.11",
-				"realpath-native": "^1.0.0",
-				"slash": "^1.0.0",
-				"strip-bom": "3.0.0",
-				"write-file-atomic": "^2.1.0",
-				"yargs": "^11.0.0"
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.8.0",
+				"jest-haste-map": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-mock": "^24.8.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.8.0",
+				"jest-snapshot": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-validate": "^24.8.0",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"strip-bom": "^3.0.0",
+				"yargs": "^12.0.2"
 			},
 			"dependencies": {
-				"babel-core": {
-					"version": "6.26.3",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+				"jest-resolve": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+					"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
 					"requires": {
-						"babel-code-frame": "^6.26.0",
-						"babel-generator": "^6.26.0",
-						"babel-helpers": "^6.24.1",
-						"babel-messages": "^6.23.0",
-						"babel-register": "^6.26.0",
-						"babel-runtime": "^6.26.0",
-						"babel-template": "^6.26.0",
-						"babel-traverse": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"convert-source-map": "^1.5.1",
-						"debug": "^2.6.9",
-						"json5": "^0.5.1",
-						"lodash": "^4.17.4",
-						"minimatch": "^3.0.4",
-						"path-is-absolute": "^1.0.1",
-						"private": "^0.1.8",
-						"slash": "^1.0.0",
-						"source-map": "^0.5.7"
+						"@jest/types": "^24.8.0",
+						"browser-resolve": "^1.11.3",
+						"chalk": "^2.0.1",
+						"jest-pnp-resolver": "^1.2.1",
+						"realpath-native": "^1.1.0"
 					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				}
 			}
 		},
 		"jest-serializer": {
-			"version": "23.0.1",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-			"integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU="
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+			"integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q=="
 		},
 		"jest-snapshot": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
-			"integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
+			"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
 			"requires": {
-				"babel-types": "^6.0.0",
+				"@babel/types": "^7.0.0",
+				"@jest/types": "^24.8.0",
 				"chalk": "^2.0.1",
-				"jest-diff": "^23.6.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-resolve": "^23.6.0",
+				"expect": "^24.8.0",
+				"jest-diff": "^24.8.0",
+				"jest-matcher-utils": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-resolve": "^24.8.0",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^23.6.0",
+				"pretty-format": "^24.8.0",
 				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"jest-resolve": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+					"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"browser-resolve": "^1.11.3",
+						"chalk": "^2.0.1",
+						"jest-pnp-resolver": "^1.2.1",
+						"realpath-native": "^1.1.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"jest-util": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
-			"integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
+			"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
 			"requires": {
-				"callsites": "^2.0.0",
+				"@jest/console": "^24.7.1",
+				"@jest/fake-timers": "^24.8.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"callsites": "^3.0.0",
 				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.11",
-				"is-ci": "^1.0.10",
-				"jest-message-util": "^23.4.0",
+				"graceful-fs": "^4.1.15",
+				"is-ci": "^2.0.0",
 				"mkdirp": "^0.5.1",
-				"slash": "^1.0.0",
+				"slash": "^2.0.0",
 				"source-map": "^0.6.0"
 			},
 			"dependencies": {
 				"callsites": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"jest-validate": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
-			"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
+			"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
 			"requires": {
+				"@jest/types": "^24.8.0",
+				"camelcase": "^5.0.0",
 				"chalk": "^2.0.1",
-				"jest-get-type": "^22.1.0",
+				"jest-get-type": "^24.8.0",
 				"leven": "^2.1.0",
-				"pretty-format": "^23.6.0"
+				"pretty-format": "^24.8.0"
+			}
+		},
+		"jest-watch-typeahead": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-0.3.0.tgz",
+			"integrity": "sha512-+uOtlppt9ysST6k6ZTqsPI0WNz2HLa8bowiZylZoQCQaAVn7XsVmHhZREkz73FhKelrFrpne4hQQjdq42nFEmA==",
+			"requires": {
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.4.1",
+				"jest-watcher": "^24.3.0",
+				"slash": "^2.0.0",
+				"string-length": "^2.0.0",
+				"strip-ansi": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
 			}
 		},
 		"jest-watcher": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
-			"integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
+			"integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
 			"requires": {
+				"@jest/test-result": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"@types/yargs": "^12.0.9",
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.1",
+				"jest-util": "^24.8.0",
 				"string-length": "^2.0.0"
 			}
 		},
 		"jest-worker": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
-			"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+			"version": "24.6.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+			"integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
 			"requires": {
-				"merge-stream": "^1.0.1"
-			}
-		},
-		"joi": {
-			"version": "11.4.0",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
-			"integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
-			"requires": {
-				"hoek": "4.x.x",
-				"isemail": "3.x.x",
-				"topo": "2.x.x"
+				"merge-stream": "^1.0.1",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"js-levenshtein": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
-			"integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow=="
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+			"integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -6972,9 +7515,9 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -6986,48 +7529,54 @@
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"jsdom": {
-			"version": "12.2.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-12.2.0.tgz",
-			"integrity": "sha512-QPOggIJ8fquWPLaYYMoh+zqUmdphDtu1ju0QGTitZT1Yd8I5qenPpXM1etzUegu3MjVp8XPzgZxdn8Yj7e40ig==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
 			"requires": {
 				"abab": "^2.0.0",
-				"acorn": "^6.0.2",
-				"acorn-globals": "^4.3.0",
+				"acorn": "^5.5.3",
+				"acorn-globals": "^4.1.0",
 				"array-equal": "^1.0.0",
-				"cssom": "^0.3.4",
-				"cssstyle": "^1.1.1",
-				"data-urls": "^1.0.1",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": "^1.0.0",
+				"data-urls": "^1.0.0",
 				"domexception": "^1.0.1",
-				"escodegen": "^1.11.0",
+				"escodegen": "^1.9.1",
 				"html-encoding-sniffer": "^1.0.2",
-				"nwsapi": "^2.0.9",
-				"parse5": "5.1.0",
+				"left-pad": "^1.3.0",
+				"nwsapi": "^2.0.7",
+				"parse5": "4.0.0",
 				"pn": "^1.1.0",
-				"request": "^2.88.0",
+				"request": "^2.87.0",
 				"request-promise-native": "^1.0.5",
-				"saxes": "^3.1.3",
+				"sax": "^1.2.4",
 				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.4.3",
+				"tough-cookie": "^2.3.4",
 				"w3c-hr-time": "^1.0.1",
 				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.5",
-				"whatwg-mimetype": "^2.2.0",
-				"whatwg-url": "^7.0.0",
-				"ws": "^6.1.0",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-mimetype": "^2.1.0",
+				"whatwg-url": "^6.4.1",
+				"ws": "^5.2.0",
 				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
-					"integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg=="
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+				},
+				"parse5": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
 				}
 			}
 		},
 		"jsesc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
@@ -7040,9 +7589,9 @@
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
@@ -7063,14 +7612,17 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json3": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+			"integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
 		},
 		"json5": {
-			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"requires": {
+				"minimist": "^1.2.0"
+			}
 		},
 		"jsonfile": {
 			"version": "4.0.0",
@@ -7097,9 +7649,9 @@
 			}
 		},
 		"jsx-ast-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
+			"integrity": "sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==",
 			"requires": {
 				"array-includes": "^3.0.3"
 			}
@@ -7115,12 +7667,19 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
 				"is-buffer": "^1.1.5"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+				}
 			}
 		},
 		"kleur": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
-			"integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ=="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
 		},
 		"last-call-webpack-plugin": {
 			"version": "3.0.0",
@@ -7137,11 +7696,11 @@
 			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
 		},
 		"lcid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "^2.0.0"
 			}
 		},
 		"left-pad": {
@@ -7164,31 +7723,20 @@
 			}
 		},
 		"load-json-file": {
-			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
-			},
-			"dependencies": {
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				}
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"loader-fs-cache": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
-			"integrity": "sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
+			"integrity": "sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==",
 			"requires": {
 				"find-cache-dir": "^0.1.1",
 				"mkdirp": "0.5.1"
@@ -7232,26 +7780,36 @@
 			}
 		},
 		"loader-runner": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
-			"integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw=="
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+			"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
 		},
 		"loader-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+			"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
 			"requires": {
-				"big.js": "^3.1.3",
+				"big.js": "^5.2.2",
 				"emojis-list": "^2.0.0",
-				"json5": "^0.5.0"
+				"json5": "^1.0.1"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				}
 			}
 		},
 		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 			"requires": {
-				"p-locate": "^2.0.0",
+				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
 			}
 		},
@@ -7264,16 +7822,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
 			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-		},
-		"lodash.camelcase": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-		},
-		"lodash.debounce": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
@@ -7307,6 +7855,11 @@
 				"lodash._reinterpolate": "~3.0.0"
 			}
 		},
+		"lodash.unescape": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
+		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -7331,26 +7884,31 @@
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
 		},
 		"lru-cache": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"yallist": "^3.0.2"
 			}
 		},
 		"make-dir": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "^4.0.1",
+				"semver": "^5.6.0"
 			},
 			"dependencies": {
 				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -7368,9 +7926,9 @@
 			"integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
 		},
 		"map-age-cleaner": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
-			"integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
 			"requires": {
 				"p-defer": "^1.0.0"
 			}
@@ -7387,11 +7945,6 @@
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
-		},
-		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -7410,15 +7963,24 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+				}
 			}
 		},
 		"memoize-one": {
@@ -7434,11 +7996,6 @@
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
 			}
-		},
-		"merge": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-			"integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
 		},
 		"merge-deep": {
 			"version": "3.0.2",
@@ -7463,29 +8020,46 @@
 				"readable-stream": "^2.0.1"
 			}
 		},
+		"merge2": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+		},
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
+		"microevent.ts": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
+			"integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g=="
+		},
 		"micromatch": {
-			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
 			}
 		},
 		"microsoft-speech-browser-sdk": {
@@ -7503,21 +8077,21 @@
 			}
 		},
 		"mime": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-			"integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+			"integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw=="
 		},
 		"mime-db": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
 		},
 		"mime-types": {
-			"version": "2.1.21",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+			"version": "2.1.24",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
 			"requires": {
-				"mime-db": "~1.37.0"
+				"mime-db": "1.40.0"
 			}
 		},
 		"mimic-fn": {
@@ -7526,9 +8100,9 @@
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"mini-css-extract-plugin": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.3.tgz",
-			"integrity": "sha512-Mxs0nxzF1kxPv4TRi2NimewgXlJqh0rGE30vviCU2WHrpbta6wklnUV9dr9FUtoAHmB3p3LeXEC+ZjgHvB0Dzg==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz",
+			"integrity": "sha512-IuaLjruM0vMKhUUT51fQdQzBYTX49dLj8w68ALEAe2A4iYNpIC4eMac67mt3NzycvjOlf07/kYxJDc0RTl1Wqw==",
 			"requires": {
 				"loader-utils": "^1.1.0",
 				"schema-utils": "^1.0.0",
@@ -7554,9 +8128,9 @@
 			}
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"mississippi": {
 			"version": "3.0.0",
@@ -7612,10 +8186,17 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+				}
 			}
 		},
 		"move-concurrently": {
@@ -7632,9 +8213,9 @@
 			}
 		},
 		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
@@ -7656,9 +8237,9 @@
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 			"optional": true
 		},
 		"nanomatch": {
@@ -7679,16 +8260,6 @@
 				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -7702,14 +8273,14 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
 		"negotiator": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
 		"neo-async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
 		},
 		"nice-try": {
 			"version": "1.0.5",
@@ -7744,9 +8315,9 @@
 			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
 		},
 		"node-libs-browser": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
+			"integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
 			"requires": {
 				"assert": "^1.1.1",
 				"browserify-zlib": "^0.2.0",
@@ -7755,7 +8326,7 @@
 				"constants-browserify": "^1.0.0",
 				"crypto-browserify": "^3.11.0",
 				"domain-browser": "^1.1.1",
-				"events": "^1.0.0",
+				"events": "^3.0.0",
 				"https-browserify": "^1.0.0",
 				"os-browserify": "^0.3.0",
 				"path-browserify": "0.0.0",
@@ -7769,7 +8340,7 @@
 				"timers-browserify": "^2.0.4",
 				"tty-browserify": "0.0.0",
 				"url": "^0.11.0",
-				"util": "^0.10.3",
+				"util": "^0.11.0",
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
@@ -7780,34 +8351,61 @@
 				}
 			}
 		},
+		"node-modules-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+		},
 		"node-notifier": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
-			"integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
 			"requires": {
 				"growly": "^1.3.0",
+				"is-wsl": "^1.1.0",
 				"semver": "^5.5.0",
 				"shellwords": "^0.1.1",
 				"which": "^1.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"node-releases": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.1.tgz",
-			"integrity": "sha512-/kOv7jA26OBwkBPx6B9xR/FzJzs2OkMtcWjS8uPQRMHE7IELdSfN0QKZvmiWnf5P1QJ8oYq/e9qe0aCZISB1pQ==",
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
+			"integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
 			"requires": {
 				"semver": "^5.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"requires": {
 				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
+				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"normalize-path": {
@@ -7855,9 +8453,9 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwsapi": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ=="
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+			"integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw=="
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
@@ -7890,14 +8488,14 @@
 			}
 		},
 		"object-hash": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz",
-			"integrity": "sha512-05KzQ70lSeGSrZJQXE5wNDiTkBJDlUT/myi6RX9dVIvz7a7Qh4oH93BQdiPMn27nldYvVQCKMUaM83AfizZlsQ=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+			"integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
 		},
 		"object-keys": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -7918,6 +8516,17 @@
 				"object-keys": "^1.0.11"
 			}
 		},
+		"object.fromentries": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+			"integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.11.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.1"
+			}
+		},
 		"object.getownpropertydescriptors": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
@@ -7925,15 +8534,6 @@
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.5.1"
-			}
-		},
-		"object.omit": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
@@ -7945,14 +8545,14 @@
 			}
 		},
 		"object.values": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
-			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+			"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.6.1",
-				"function-bind": "^1.1.0",
-				"has": "^1.0.1"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.12.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
 			}
 		},
 		"obuf": {
@@ -7969,9 +8569,9 @@
 			}
 		},
 		"on-headers": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
 		},
 		"once": {
 			"version": "1.4.0",
@@ -8006,6 +8606,11 @@
 				"wordwrap": "~0.0.2"
 			},
 			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+				},
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -8048,10 +8653,15 @@
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
 			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		"os-locale": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+			"requires": {
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
+			}
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
@@ -8063,30 +8673,38 @@
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
 			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
 		},
+		"p-each-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+			"requires": {
+				"p-reduce": "^1.0.0"
+			}
+		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-is-promise": {
-			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
 		},
 		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "^2.0.0"
 			}
 		},
 		"p-map": {
@@ -8094,15 +8712,20 @@
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
 			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
 		},
-		"p-try": {
+		"p-reduce": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
+		},
+		"p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"pako": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
 		},
 		"parallel-transform": {
 			"version": "1.1.0",
@@ -8122,27 +8745,32 @@
 				"no-case": "^2.2.0"
 			}
 		},
+		"parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"requires": {
+				"callsites": "^3.0.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+				}
+			}
+		},
 		"parse-asn1": {
-			"version": "5.1.1",
-			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
-			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
+			"integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
 				"create-hash": "^1.1.0",
 				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3"
-			}
-		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
+				"pbkdf2": "^3.0.3",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"parse-json": {
@@ -8154,20 +8782,15 @@
 				"json-parse-better-errors": "^1.0.1"
 			}
 		},
-		"parse-passwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
-		},
 		"parse5": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
 			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
 		},
 		"parseurl": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -8215,13 +8838,11 @@
 			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"path-type": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"pbkdf2": {
@@ -8242,9 +8863,9 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
-			"version": "2.3.0",
-			"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 		},
 		"pinkie": {
 			"version": "2.0.4",
@@ -8259,12 +8880,20 @@
 				"pinkie": "^2.0.0"
 			}
 		},
-		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+		"pirates": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
 			"requires": {
-				"find-up": "^2.1.0"
+				"node-modules-regexp": "^1.0.0"
+			}
+		},
+		"pkg-dir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+			"requires": {
+				"find-up": "^3.0.0"
 			}
 		},
 		"pkg-up": {
@@ -8273,12 +8902,47 @@
 			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
 			"requires": {
 				"find-up": "^2.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+				}
 			}
-		},
-		"pluralize": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
 		},
 		"pn": {
 			"version": "1.1.0",
@@ -8286,24 +8950,35 @@
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
 		},
 		"pnp-webpack-plugin": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.1.0.tgz",
-			"integrity": "sha512-CPCdcFxx7fEcDMWTDjXe2Wypt4JuMt4q5Q2UrpTcyBBkLiCIyPEh/mCGmUWIcNkKGyXwQ9Y2wVhlKm6ketiBNQ=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.2.1.tgz",
+			"integrity": "sha512-W6GctK7K2qQiVR+gYSv/Gyt6jwwIH4vwdviFqx+Y2jAtVf5eZyYIDf5Ac2NCDMBiX5yWscBLZElPTsyA1UtVVA==",
+			"requires": {
+				"ts-pnp": "^1.0.0"
+			}
 		},
 		"portfinder": {
-			"version": "1.0.19",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.19.tgz",
-			"integrity": "sha512-23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==",
+			"version": "1.0.20",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
+			"integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
 			"requires": {
 				"async": "^1.5.2",
 				"debug": "^2.2.0",
 				"mkdirp": "0.5.x"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -8313,34 +8988,62 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"postcss": {
-			"version": "6.0.23",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-			"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+			"version": "7.0.16",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+			"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
 			"requires": {
-				"chalk": "^2.4.1",
+				"chalk": "^2.4.2",
 				"source-map": "^0.6.1",
-				"supports-color": "^5.4.0"
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"postcss-attribute-case-insensitive": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.0.tgz",
-			"integrity": "sha512-K/zqdg0/UgUgC8qR0lDuxYzmowPpnvrrNC5YuoqzhHMubR9AuhsPlpVu3jjkLHgDAzR+ohD/m7//iGnN9WxbzQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
+			"integrity": "sha512-L2YKB3vF4PetdTIthQVeT+7YiSzMoNMLLYxPXXppOOP7NoazEAy45sh2LvJ8leCQjfBcfkYQs8TtCcQjeZTp8A==",
 			"requires": {
 				"postcss": "^7.0.2",
-				"postcss-selector-parser": "^5.0.0-rc.3"
+				"postcss-selector-parser": "^5.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+				},
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				}
+			}
+		},
+		"postcss-browser-comments": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-2.0.0.tgz",
+			"integrity": "sha512-xGG0UvoxwBc4Yx4JX3gc0RuDl1kc4bVihCzzk6UC72YPfq5fu3c717Nu8Un3nvnq1BJ31gBnFXIG/OaUTnpHgA==",
+			"requires": {
+				"postcss": "^7.0.2"
 			}
 		},
 		"postcss-calc": {
@@ -8354,14 +9057,19 @@
 				"postcss-value-parser": "^3.3.1"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+				},
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				}
 			}
@@ -8373,39 +9081,25 @@
 			"requires": {
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
+			}
+		},
+		"postcss-color-gray": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz",
+			"integrity": "sha512-q6BuRnAGKM/ZRpfDascZlIZPjvwsRye7UDNalqVz3s7GDxMtqPY6+Q871liNxsonUw8oC61OG+PSaysYpl1bnw==",
+			"requires": {
+				"@csstools/convert-colors": "^1.4.0",
+				"postcss": "^7.0.5",
+				"postcss-values-parser": "^2.0.0"
 			}
 		},
 		"postcss-color-hex-alpha": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.2.tgz",
-			"integrity": "sha512-8bIOzQMGdZVifoBQUJdw+yIY00omBd2EwkJXepQo9cjp1UOHHHoeRDeSzTP6vakEpaRc6GAIOfvcQR7jBYaG5Q==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz",
+			"integrity": "sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==",
 			"requires": {
-				"postcss": "^7.0.2",
-				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
+				"postcss": "^7.0.14",
+				"postcss-values-parser": "^2.0.1"
 			}
 		},
 		"postcss-color-mod-function": {
@@ -8416,18 +9110,6 @@
 				"@csstools/convert-colors": "^1.4.0",
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-color-rebeccapurple": {
@@ -8437,42 +9119,18 @@
 			"requires": {
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-colormin": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.2.tgz",
-			"integrity": "sha512-1QJc2coIehnVFsz0otges8kQLsryi4lo19WD+U5xCWvXd0uw/Z+KKYnbiNDCnO9GP+PvErPHCG0jNvWTngk9Rw==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+			"integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
 			"requires": {
 				"browserslist": "^4.0.0",
 				"color": "^3.0.0",
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-convert-values": {
@@ -8482,59 +9140,23 @@
 			"requires": {
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-custom-media": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.7.tgz",
-			"integrity": "sha512-bWPCdZKdH60wKOTG4HKEgxWnZVjAIVNOJDvi3lkuTa90xo/K0YHa2ZnlKLC5e2qF8qCcMQXt0yzQITBp8d0OFA==",
+			"version": "7.0.8",
+			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz",
+			"integrity": "sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==",
 			"requires": {
-				"postcss": "^7.0.5"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
+				"postcss": "^7.0.14"
 			}
 		},
 		"postcss-custom-properties": {
-			"version": "8.0.8",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.8.tgz",
-			"integrity": "sha512-G3U8uSxj0B4jPJ1QBF5WYeW716n5HV/wcH2lOTV1V+EI+F0T0/ZOhl32MLLTMD79bN2mE77IOoclbCoLl4QtPA==",
+			"version": "8.0.10",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.10.tgz",
+			"integrity": "sha512-GDL0dyd7++goDR4SSasYdRNNvp4Gqy1XMzcCnTijiph7VB27XXpJ8bW/AI0i2VSBZ55TpdGhMr37kMSpRfYD0Q==",
 			"requires": {
-				"postcss": "^7.0.5",
-				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
+				"postcss": "^7.0.14",
+				"postcss-values-parser": "^2.0.1"
 			}
 		},
 		"postcss-custom-selectors": {
@@ -8546,14 +9168,19 @@
 				"postcss-selector-parser": "^5.0.0-rc.3"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+				},
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				}
 			}
@@ -8567,36 +9194,29 @@
 				"postcss-selector-parser": "^5.0.0-rc.3"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+				},
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				}
 			}
 		},
 		"postcss-discard-comments": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.1.tgz",
-			"integrity": "sha512-Ay+rZu1Sz6g8IdzRjUgG2NafSNpp2MSMOQUb+9kkzzzP+kh07fP0yNbhtFejURnyVXSX3FYy2nVNW1QTnNjgBQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+			"integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-discard-duplicates": {
@@ -8605,18 +9225,6 @@
 			"integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-discard-empty": {
@@ -8625,18 +9233,6 @@
 			"integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-discard-overridden": {
@@ -8645,18 +9241,15 @@
 			"integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
+			}
+		},
+		"postcss-double-position-gradients": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz",
+			"integrity": "sha512-G+nV8EnQq25fOI8CH/B6krEohGWnF5+3A6H/+JEpOncu5dCnkS1QQ6+ct3Jkaepw1NGVqqOZH6lqrm244mCftA==",
+			"requires": {
+				"postcss": "^7.0.5",
+				"postcss-values-parser": "^2.0.0"
 			}
 		},
 		"postcss-env-function": {
@@ -8666,18 +9259,6 @@
 			"requires": {
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-flexbugs-fixes": {
@@ -8686,18 +9267,6 @@
 			"integrity": "sha512-jr1LHxQvStNNAHlgco6PzY308zvLklh7SJVYuWUwyUQncofaAlD2l+P/gxKHOdqWKe7xJSkVLFF/2Tp+JqMSZA==",
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-focus-visible": {
@@ -8706,18 +9275,6 @@
 			"integrity": "sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==",
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-focus-within": {
@@ -8726,18 +9283,6 @@
 			"integrity": "sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==",
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-font-variant": {
@@ -8746,18 +9291,6 @@
 			"integrity": "sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==",
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-gap-properties": {
@@ -8766,18 +9299,6 @@
 			"integrity": "sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==",
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-image-set-function": {
@@ -8787,18 +9308,6 @@
 			"requires": {
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-initial": {
@@ -8808,18 +9317,6 @@
 			"requires": {
 				"lodash.template": "^4.2.4",
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-lab-function": {
@@ -8830,18 +9327,6 @@
 				"@csstools/convert-colors": "^1.4.0",
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-load-config": {
@@ -8875,18 +9360,6 @@
 				"postcss": "^7.0.0",
 				"postcss-load-config": "^2.0.0",
 				"schema-utils": "^1.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-logical": {
@@ -8895,18 +9368,6 @@
 			"integrity": "sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==",
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-media-minmax": {
@@ -8915,47 +9376,23 @@
 			"integrity": "sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==",
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-merge-longhand": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.9.tgz",
-			"integrity": "sha512-UVMXrXF5K/kIwUbK/crPFCytpWbNX2Q3dZSc8+nQUgfOHrCT4+MHncpdxVphUlQeZxlLXUJbDyXc5NBhTnS2tA==",
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+			"integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
 			"requires": {
 				"css-color-names": "0.0.4",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0",
 				"stylehacks": "^4.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-merge-rules": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.2.tgz",
-			"integrity": "sha512-UiuXwCCJtQy9tAIxsnurfF0mrNHKc4NnNx6NxqmzNNjXpQwLSukUxELHTRF0Rg1pAmcoKLih8PwvZbiordchag==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+			"integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
 			"requires": {
 				"browserslist": "^4.0.0",
 				"caniuse-api": "^3.0.0",
@@ -8965,16 +9402,6 @@
 				"vendors": "^1.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				},
 				"postcss-selector-parser": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -8994,47 +9421,23 @@
 			"requires": {
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-minify-gradients": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.1.tgz",
-			"integrity": "sha512-pySEW3E6Ly5mHm18rekbWiAjVi/Wj8KKt2vwSfVFAWdW6wOIekgqxKxLU7vJfb107o3FDNPkaYFCxGAJBFyogA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+			"integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
 			"requires": {
 				"cssnano-util-get-arguments": "^4.0.0",
 				"is-color-stop": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-minify-params": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.1.tgz",
-			"integrity": "sha512-h4W0FEMEzBLxpxIVelRtMheskOKKp52ND6rJv+nBS33G1twu2tCyurYj/YtgU76+UDCvWeNs0hs8HFAWE2OUFg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+			"integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
 			"requires": {
 				"alphanum-sort": "^1.0.0",
 				"browserslist": "^4.0.0",
@@ -9042,24 +9445,12 @@
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0",
 				"uniqs": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-minify-selectors": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.1.tgz",
-			"integrity": "sha512-8+plQkomve3G+CodLCgbhAKrb5lekAnLYuL1d7Nz+/7RANpBEVdgBkPNwljfSKvZ9xkkZTZITd04KP+zeJTJqg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+			"integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
 			"requires": {
 				"alphanum-sort": "^1.0.0",
 				"has": "^1.0.0",
@@ -9067,16 +9458,6 @@
 				"postcss-selector-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				},
 				"postcss-selector-parser": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -9090,38 +9471,39 @@
 			}
 		},
 		"postcss-modules-extract-imports": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
-			"integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+			"integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
 			"requires": {
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.5"
 			}
 		},
 		"postcss-modules-local-by-default": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
-			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
+			"integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
 			"requires": {
-				"css-selector-tokenizer": "^0.7.0",
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.6",
+				"postcss-selector-parser": "^6.0.0",
+				"postcss-value-parser": "^3.3.1"
 			}
 		},
 		"postcss-modules-scope": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
-			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
+			"integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
 			"requires": {
-				"css-selector-tokenizer": "^0.7.0",
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.6",
+				"postcss-selector-parser": "^6.0.0"
 			}
 		},
 		"postcss-modules-values": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
-			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
+			"integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
 			"requires": {
 				"icss-replace-symbols": "^1.1.0",
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.6"
 			}
 		},
 		"postcss-nesting": {
@@ -9130,18 +9512,17 @@
 			"integrity": "sha512-WSsbVd5Ampi3Y0nk/SKr5+K34n52PqMqEfswu6RtU4r7wA8vSD+gM8/D9qq4aJkHImwn1+9iEFTbjoWsQeqtaQ==",
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
+			}
+		},
+		"postcss-normalize": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize/-/postcss-normalize-7.0.1.tgz",
+			"integrity": "sha512-NOp1fwrG+6kVXWo7P9SizCHX6QvioxFD/hZcI2MLxPmVnFJFC0j0DDpIuNw2tUDeCFMni59gCVgeJ1/hYhj2OQ==",
+			"requires": {
+				"@csstools/normalize.css": "^9.0.1",
+				"browserslist": "^4.1.1",
+				"postcss": "^7.0.2",
+				"postcss-browser-comments": "^2.0.0"
 			}
 		},
 		"postcss-normalize-charset": {
@@ -9150,130 +9531,58 @@
 			"integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-display-values": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.1.tgz",
-			"integrity": "sha512-R5mC4vaDdvsrku96yXP7zak+O3Mm9Y8IslUobk7IMP+u/g+lXvcN4jngmHY5zeJnrQvE13dfAg5ViU05ZFDwdg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+			"integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
 			"requires": {
 				"cssnano-util-get-match": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-positions": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.1.tgz",
-			"integrity": "sha512-GNoOaLRBM0gvH+ZRb2vKCIujzz4aclli64MBwDuYGU2EY53LwiP7MxOZGE46UGtotrSnmarPPZ69l2S/uxdaWA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+			"integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
 			"requires": {
 				"cssnano-util-get-arguments": "^4.0.0",
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-repeat-style": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.1.tgz",
-			"integrity": "sha512-fFHPGIjBUyUiswY2rd9rsFcC0t3oRta4wxE1h3lpwfQZwFeFjXFSiDtdJ7APCmHQOnUZnqYBADNRPKPwFAONgA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+			"integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
 			"requires": {
 				"cssnano-util-get-arguments": "^4.0.0",
 				"cssnano-util-get-match": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-string": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.1.tgz",
-			"integrity": "sha512-IJoexFTkAvAq5UZVxWXAGE0yLoNN/012v7TQh5nDo6imZJl2Fwgbhy3J2qnIoaDBrtUP0H7JrXlX1jjn2YcvCQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+			"integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
 			"requires": {
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-timing-functions": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.1.tgz",
-			"integrity": "sha512-1nOtk7ze36+63ONWD8RCaRDYsnzorrj+Q6fxkQV+mlY5+471Qx9kspqv0O/qQNMeApg8KNrRf496zHwJ3tBZ7w==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+			"integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
 			"requires": {
 				"cssnano-util-get-match": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-unicode": {
@@ -9284,18 +9593,6 @@
 				"browserslist": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-url": {
@@ -9307,61 +9604,25 @@
 				"normalize-url": "^3.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-whitespace": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.1.tgz",
-			"integrity": "sha512-U8MBODMB2L+nStzOk6VvWWjZgi5kQNShCyjRhMT3s+W9Jw93yIjOnrEkKYD3Ul7ChWbEcjDWmXq0qOL9MIAnAw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+			"integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
 			"requires": {
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-ordered-values": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.1.tgz",
-			"integrity": "sha512-PeJiLgJWPzkVF8JuKSBcylaU+hDJ/TX3zqAMIjlghgn1JBi6QwQaDZoDIlqWRcCAI8SxKrt3FCPSRmOgKRB97Q==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+			"integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
 			"requires": {
 				"cssnano-util-get-arguments": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-overflow-shorthand": {
@@ -9370,18 +9631,6 @@
 			"integrity": "sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==",
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-page-break": {
@@ -9390,18 +9639,6 @@
 			"integrity": "sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==",
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-place": {
@@ -9411,39 +9648,32 @@
 			"requires": {
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-preset-env": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.0.6.tgz",
-			"integrity": "sha512-W1Wtqngl7BMe4s9o76odTaVs4HXVLhOHD+L5Ez+7x15yiA+98W/WVO6IPlC1q9BIkgAckRtUFmEDr0sNufXZIQ==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.6.0.tgz",
+			"integrity": "sha512-I3zAiycfqXpPIFD6HXhLfWXIewAWO8emOKz+QSsxaUZb9Dp8HbF5kUf+4Wy/AxR33o+LRoO8blEWCHth0ZsCLA==",
 			"requires": {
-				"autoprefixer": "^9.1.5",
-				"browserslist": "^4.1.1",
-				"caniuse-lite": "^1.0.30000887",
-				"cssdb": "^3.2.1",
-				"postcss": "^7.0.2",
-				"postcss-attribute-case-insensitive": "^4.0.0",
+				"autoprefixer": "^9.4.9",
+				"browserslist": "^4.4.2",
+				"caniuse-lite": "^1.0.30000939",
+				"css-blank-pseudo": "^0.1.4",
+				"css-has-pseudo": "^0.10.0",
+				"css-prefers-color-scheme": "^3.1.1",
+				"cssdb": "^4.3.0",
+				"postcss": "^7.0.14",
+				"postcss-attribute-case-insensitive": "^4.0.1",
 				"postcss-color-functional-notation": "^2.0.1",
+				"postcss-color-gray": "^5.0.0",
 				"postcss-color-hex-alpha": "^5.0.2",
 				"postcss-color-mod-function": "^3.0.3",
 				"postcss-color-rebeccapurple": "^4.0.1",
-				"postcss-custom-media": "^7.0.4",
-				"postcss-custom-properties": "^8.0.5",
+				"postcss-custom-media": "^7.0.7",
+				"postcss-custom-properties": "^8.0.9",
 				"postcss-custom-selectors": "^5.1.2",
 				"postcss-dir-pseudo-class": "^5.0.0",
+				"postcss-double-position-gradients": "^1.0.0",
 				"postcss-env-function": "^2.0.2",
 				"postcss-focus-visible": "^4.0.0",
 				"postcss-focus-within": "^3.0.0",
@@ -9462,18 +9692,6 @@
 				"postcss-replace-overflow-wrap": "^3.0.0",
 				"postcss-selector-matches": "^4.0.0",
 				"postcss-selector-not": "^4.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-pseudo-class-any-link": {
@@ -9485,62 +9703,43 @@
 				"postcss-selector-parser": "^5.0.0-rc.3"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+				},
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				}
 			}
 		},
 		"postcss-reduce-initial": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.2.tgz",
-			"integrity": "sha512-epUiC39NonKUKG+P3eAOKKZtm5OtAtQJL7Ye0CBN1f+UQTHzqotudp+hki7zxXm7tT0ZAKDMBj1uihpPjP25ug==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+			"integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
 			"requires": {
 				"browserslist": "^4.0.0",
 				"caniuse-api": "^3.0.0",
 				"has": "^1.0.0",
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-reduce-transforms": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.1.tgz",
-			"integrity": "sha512-sZVr3QlGs0pjh6JAIe6DzWvBaqYw05V1t3d9Tp+VnFRT5j+rsqoWsysh/iSD7YNsULjq9IAylCznIwVd5oU/zA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+			"integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
 			"requires": {
 				"cssnano-util-get-match": "^4.0.0",
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-replace-overflow-wrap": {
@@ -9549,18 +9748,6 @@
 			"integrity": "sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==",
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-safe-parser": {
@@ -9569,18 +9756,6 @@
 			"integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-selector-matches": {
@@ -9590,18 +9765,6 @@
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-selector-not": {
@@ -9611,58 +9774,27 @@
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-selector-parser": {
-			"version": "5.0.0-rc.4",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0-rc.4.tgz",
-			"integrity": "sha512-0XvfYuShrKlTk1ooUrVzMCFQRcypsdEIsGqh5IxC5rdtBi4/M/tDAJeSONwC2MTqEFsmPZYAV7Dd4X8rgAfV0A==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+			"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
 			"requires": {
-				"cssesc": "^2.0.0",
+				"cssesc": "^3.0.0",
 				"indexes-of": "^1.0.1",
 				"uniq": "^1.0.1"
-			},
-			"dependencies": {
-				"cssesc": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
-					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
-				}
 			}
 		},
 		"postcss-svgo": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.1.tgz",
-			"integrity": "sha512-YD5uIk5NDRySy0hcI+ZJHwqemv2WiqqzDgtvgMzO8EGSkK5aONyX8HMVFRFJSdO8wUWTuisUFn/d7yRRbBr5Qw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
+			"integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
 			"requires": {
 				"is-svg": "^3.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0",
 				"svgo": "^1.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-unique-selectors": {
@@ -9673,18 +9805,6 @@
 				"alphanum-sort": "^1.0.0",
 				"postcss": "^7.0.0",
 				"uniqs": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				}
 			}
 		},
 		"postcss-value-parser": {
@@ -9693,9 +9813,9 @@
 			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
 		},
 		"postcss-values-parser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.0.tgz",
-			"integrity": "sha512-cyRdkgbRRefu91ByAlJow4y9w/hnBmmWgLpWmlFQ2bpIy2eKrqowt3VeYcaHQ08otVXmC9V2JtYW1Z/RpvYR8A==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+			"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
 			"requires": {
 				"flatten": "^1.0.2",
 				"indexes-of": "^1.0.1",
@@ -9707,20 +9827,10 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
-		"preserve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-		},
-		"prettier": {
-			"version": "1.14.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
-			"integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg=="
-		},
 		"pretty-bytes": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
-			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.2.0.tgz",
+			"integrity": "sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w=="
 		},
 		"pretty-error": {
 			"version": "2.1.1",
@@ -9732,18 +9842,20 @@
 			}
 		},
 		"pretty-format": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+			"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
 			"requires": {
-				"ansi-regex": "^3.0.0",
-				"ansi-styles": "^3.2.0"
+				"@jest/types": "^24.8.0",
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0",
+				"react-is": "^16.8.4"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				}
 			}
 		},
@@ -9763,9 +9875,9 @@
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"progress": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-			"integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg=="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -9781,12 +9893,12 @@
 			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 		},
 		"prompts": {
-			"version": "0.1.14",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
-			"integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
+			"integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
 			"requires": {
-				"kleur": "^2.0.1",
-				"sisteransi": "^0.1.1"
+				"kleur": "^3.0.2",
+				"sisteransi": "^1.0.0"
 			}
 		},
 		"prop-types": {
@@ -9798,13 +9910,21 @@
 				"object-assign": "^4.1.1"
 			}
 		},
+		"property-information": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-5.1.0.tgz",
+			"integrity": "sha512-tODH6R3+SwTkAQckSp2S9xyYX8dEKYkeXw+4TmJzTxnNzd6mQPu1OD4f9zPrvw/Rm4wpPgI+Zp63mNSGNzUgHg==",
+			"requires": {
+				"xtend": "^4.0.1"
+			}
+		},
 		"proxy-addr": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
 			"requires": {
 				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.8.0"
+				"ipaddr.js": "1.9.0"
 			}
 		},
 		"prr": {
@@ -9812,15 +9932,10 @@
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
 			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+			"version": "1.1.32",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+			"integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -9891,44 +10006,22 @@
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
 		"querystringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-			"integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
 		},
 		"raf": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
-			"integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
 			"requires": {
 				"performance-now": "^2.1.0"
 			}
 		},
-		"randomatic": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
-			}
-		},
 		"randombytes": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -9943,28 +10036,25 @@
 			}
 		},
 		"range-parser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
 		},
 		"raw-body": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
 			"requires": {
-				"bytes": "3.0.0",
-				"http-errors": "1.6.3",
-				"iconv-lite": "0.4.23",
+				"bytes": "3.1.0",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
 			},
 			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
+				"bytes": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+					"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 				}
 			}
 		},
@@ -9980,17 +10070,23 @@
 			}
 		},
 		"react-app-polyfill": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.1.3.tgz",
-			"integrity": "sha512-Fl5Pic4F15G05qX7RmUqPZr1MtyFKJKSlRwMhel4kvDLrk/KcQ9QbpvyMTzv/0NN5957XFQ7r1BNHWi7qN59Pw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.1.tgz",
+			"integrity": "sha512-LbVpT1NdzTdDDs7xEZdebjDrqsvKi5UyVKUQqtTYYNyC1JJYVAwNQWe4ybWvoT2V2WW9PGVO2u5Y6aVj4ER/Ow==",
 			"requires": {
-				"core-js": "2.5.7",
+				"core-js": "3.0.1",
 				"object-assign": "4.1.1",
 				"promise": "8.0.2",
-				"raf": "3.4.0",
+				"raf": "3.4.1",
+				"regenerator-runtime": "0.13.2",
 				"whatwg-fetch": "3.0.0"
 			},
 			"dependencies": {
+				"core-js": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
+					"integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew=="
+				},
 				"promise": {
 					"version": "8.0.2",
 					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
@@ -10007,93 +10103,78 @@
 			}
 		},
 		"react-dev-utils": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-6.0.5.tgz",
-			"integrity": "sha512-X3/q2y8GHvcn6qzqlFhFNoIQgU4TfyerYpBTc5BrMtrSO0q1ctIheAaxDQawNeRgsm2W7L3QSQ9po+YLAGcYFQ==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.0.1.tgz",
+			"integrity": "sha512-pnaeMo/Pxel8aZpxk1WwxT3uXxM3tEwYvsjCYn5R7gNxjhN1auowdcLDzFB8kr7rafAj2rxmvfic/fbac5CzwQ==",
 			"requires": {
 				"@babel/code-frame": "7.0.0",
 				"address": "1.0.3",
-				"browserslist": "4.1.1",
-				"chalk": "2.4.1",
+				"browserslist": "4.5.4",
+				"chalk": "2.4.2",
 				"cross-spawn": "6.0.5",
 				"detect-port-alt": "1.1.6",
 				"escape-string-regexp": "1.0.5",
 				"filesize": "3.6.1",
 				"find-up": "3.0.0",
-				"global-modules": "1.0.0",
+				"fork-ts-checker-webpack-plugin": "1.1.1",
+				"global-modules": "2.0.0",
+				"globby": "8.0.2",
 				"gzip-size": "5.0.0",
-				"inquirer": "6.2.0",
+				"immer": "1.10.0",
+				"inquirer": "6.2.2",
 				"is-root": "2.0.0",
-				"loader-utils": "1.1.0",
+				"loader-utils": "1.2.3",
 				"opn": "5.4.0",
 				"pkg-up": "2.0.0",
-				"react-error-overlay": "^5.0.5",
+				"react-error-overlay": "^5.1.6",
 				"recursive-readdir": "2.2.2",
 				"shell-quote": "1.6.1",
-				"sockjs-client": "1.1.5",
-				"strip-ansi": "4.0.0",
+				"sockjs-client": "1.3.0",
+				"strip-ansi": "5.2.0",
 				"text-table": "0.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
 				"browserslist": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.1.tgz",
-					"integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
+					"version": "4.5.4",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
+					"integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
 					"requires": {
-						"caniuse-lite": "^1.0.30000884",
-						"electron-to-chromium": "^1.3.62",
-						"node-releases": "^1.0.0-alpha.11"
+						"caniuse-lite": "^1.0.30000955",
+						"electron-to-chromium": "^1.3.122",
+						"node-releases": "^1.1.13"
 					}
 				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+				"inquirer": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+					"integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
 					"requires": {
-						"locate-path": "^3.0.0"
+						"ansi-escapes": "^3.2.0",
+						"chalk": "^2.4.2",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^3.0.3",
+						"figures": "^2.0.0",
+						"lodash": "^4.17.11",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rxjs": "^6.4.0",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^5.0.0",
+						"through": "^2.3.6"
 					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^4.1.0"
 					}
 				}
 			}
@@ -10110,9 +10191,14 @@
 			}
 		},
 		"react-error-overlay": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.0.5.tgz",
-			"integrity": "sha512-ab0HWBgxdIsngHtMGU8+8gYFdTBXpUGd4AE4lN2VZvOIlBmWx9dtaWEViihuGSIGosCKPeHCnzFoRWB42UtnLg=="
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.6.tgz",
+			"integrity": "sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q=="
+		},
+		"react-is": {
+			"version": "16.8.6",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
 		},
 		"react-say": {
 			"version": "0.0.1-master.ca079e3",
@@ -10124,95 +10210,82 @@
 			}
 		},
 		"react-scripts": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-2.0.5.tgz",
-			"integrity": "sha512-ApwQM91U5FK9CPktUJQu+UhGIdgcBqqw0pvCUPYshW1jBhIgl8N3SJtd+o+I+jwRXPWAXcbJNvzsBAFDW5HHAQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.0.1.tgz",
+			"integrity": "sha512-LKEjBhVpEB+c312NeJhzF+NATxF7JkHNr5GhtwMeRS1cMeLElMeIu8Ye7WGHtDP7iz7ra4ryy48Zpo6G/cwWUw==",
 			"requires": {
-				"@babel/core": "7.1.0",
-				"@svgr/webpack": "2.4.1",
-				"babel-core": "7.0.0-bridge.0",
-				"babel-eslint": "9.0.0",
-				"babel-jest": "23.6.0",
-				"babel-loader": "8.0.4",
-				"babel-plugin-named-asset-import": "^0.2.2",
-				"babel-preset-react-app": "^5.0.4",
-				"bfj": "6.1.1",
-				"case-sensitive-paths-webpack-plugin": "2.1.2",
-				"chalk": "2.4.1",
-				"css-loader": "1.0.0",
-				"dotenv": "6.0.0",
+				"@babel/core": "7.4.3",
+				"@svgr/webpack": "4.1.0",
+				"@typescript-eslint/eslint-plugin": "1.6.0",
+				"@typescript-eslint/parser": "1.6.0",
+				"babel-eslint": "10.0.1",
+				"babel-jest": "^24.8.0",
+				"babel-loader": "8.0.5",
+				"babel-plugin-named-asset-import": "^0.3.2",
+				"babel-preset-react-app": "^9.0.0",
+				"camelcase": "^5.2.0",
+				"case-sensitive-paths-webpack-plugin": "2.2.0",
+				"css-loader": "2.1.1",
+				"dotenv": "6.2.0",
 				"dotenv-expand": "4.2.0",
-				"eslint": "5.6.0",
-				"eslint-config-react-app": "^3.0.4",
-				"eslint-loader": "2.1.1",
+				"eslint": "^5.16.0",
+				"eslint-config-react-app": "^4.0.1",
+				"eslint-loader": "2.1.2",
 				"eslint-plugin-flowtype": "2.50.1",
-				"eslint-plugin-import": "2.14.0",
-				"eslint-plugin-jsx-a11y": "6.1.2",
-				"eslint-plugin-react": "7.11.1",
-				"file-loader": "2.0.0",
-				"fs-extra": "7.0.0",
-				"fsevents": "1.2.4",
-				"html-webpack-plugin": "4.0.0-alpha.2",
+				"eslint-plugin-import": "2.16.0",
+				"eslint-plugin-jsx-a11y": "6.2.1",
+				"eslint-plugin-react": "7.12.4",
+				"eslint-plugin-react-hooks": "^1.5.0",
+				"file-loader": "3.0.1",
+				"fs-extra": "7.0.1",
+				"fsevents": "2.0.6",
+				"html-webpack-plugin": "4.0.0-beta.5",
 				"identity-obj-proxy": "3.0.0",
-				"jest": "23.6.0",
-				"jest-pnp-resolver": "1.0.1",
-				"jest-resolve": "23.6.0",
-				"mini-css-extract-plugin": "0.4.3",
+				"is-wsl": "^1.1.0",
+				"jest": "24.7.1",
+				"jest-environment-jsdom-fourteen": "0.1.0",
+				"jest-resolve": "24.7.1",
+				"jest-watch-typeahead": "0.3.0",
+				"mini-css-extract-plugin": "0.5.0",
 				"optimize-css-assets-webpack-plugin": "5.0.1",
-				"pnp-webpack-plugin": "1.1.0",
+				"pnp-webpack-plugin": "1.2.1",
 				"postcss-flexbugs-fixes": "4.1.0",
 				"postcss-loader": "3.0.0",
-				"postcss-preset-env": "6.0.6",
+				"postcss-normalize": "7.0.1",
+				"postcss-preset-env": "6.6.0",
 				"postcss-safe-parser": "4.0.1",
-				"react-app-polyfill": "^0.1.3",
-				"react-dev-utils": "^6.0.5",
-				"resolve": "1.8.1",
+				"react-app-polyfill": "^1.0.1",
+				"react-dev-utils": "^9.0.1",
+				"resolve": "1.10.0",
 				"sass-loader": "7.1.0",
-				"style-loader": "0.23.0",
-				"terser-webpack-plugin": "1.1.0",
-				"url-loader": "1.1.1",
-				"webpack": "4.19.1",
-				"webpack-dev-server": "3.1.9",
+				"semver": "6.0.0",
+				"style-loader": "0.23.1",
+				"terser-webpack-plugin": "1.2.3",
+				"ts-pnp": "1.1.2",
+				"url-loader": "1.1.2",
+				"webpack": "4.29.6",
+				"webpack-dev-server": "3.2.1",
 				"webpack-manifest-plugin": "2.0.4",
-				"workbox-webpack-plugin": "3.6.2"
+				"workbox-webpack-plugin": "4.2.0"
 			}
 		},
 		"read-pkg": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"requires": {
-				"load-json-file": "^1.0.0",
+				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
 			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				}
+				"find-up": "^3.0.0",
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"readable-stream": {
@@ -10237,257 +10310,12 @@
 				"graceful-fs": "^4.1.11",
 				"micromatch": "^3.1.10",
 				"readable-stream": "^2.0.2"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				}
 			}
 		},
 		"realpath-native": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
-			"integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
 			"requires": {
 				"util.promisify": "^1.0.0"
 			}
@@ -10506,32 +10334,24 @@
 			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
 		},
 		"regenerate-unicode-properties": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
-			"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+			"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
 			"requires": {
 				"regenerate": "^1.4.0"
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+			"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
 		},
 		"regenerator-transform": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
-			"integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
+			"integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
 			"requires": {
 				"private": "^0.1.6"
-			}
-		},
-		"regex-cache": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"requires": {
-				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"regex-not": {
@@ -10543,33 +10363,38 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regexp-tree": {
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.10.tgz",
+			"integrity": "sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ=="
+		},
 		"regexpp": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
 			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
 		},
 		"regexpu-core": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
-			"integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+			"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
 			"requires": {
 				"regenerate": "^1.4.0",
-				"regenerate-unicode-properties": "^7.0.0",
-				"regjsgen": "^0.4.0",
-				"regjsparser": "^0.3.0",
+				"regenerate-unicode-properties": "^8.0.2",
+				"regjsgen": "^0.5.0",
+				"regjsparser": "^0.6.0",
 				"unicode-match-property-ecmascript": "^1.0.4",
-				"unicode-match-property-value-ecmascript": "^1.0.2"
+				"unicode-match-property-value-ecmascript": "^1.1.0"
 			}
 		},
 		"regjsgen": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-			"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
 		},
 		"regjsparser": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
-			"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
@@ -10579,6 +10404,16 @@
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
+			}
+		},
+		"rehype-parse": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.0.tgz",
+			"integrity": "sha512-V2OjMD0xcSt39G4uRdMTqDXXm6HwkUbLMDayYKA/d037j8/OtVSQ+tqKwYWOuyBeoCs/3clXRe30VUjeMDTBSA==",
+			"requires": {
+				"hast-util-from-parse5": "^5.0.0",
+				"parse5": "^5.0.0",
+				"xtend": "^4.0.1"
 			}
 		},
 		"relateurl": {
@@ -10592,20 +10427,25 @@
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"renderkid": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.2.tgz",
-			"integrity": "sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
+			"integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
 			"requires": {
 				"css-select": "^1.1.0",
-				"dom-converter": "~0.2",
-				"htmlparser2": "~3.3.0",
+				"dom-converter": "^0.2",
+				"htmlparser2": "^3.3.0",
 				"strip-ansi": "^3.0.0",
 				"utila": "^0.4.0"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
 				"css-select": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 					"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 					"requires": {
 						"boolbase": "~1.0.0",
@@ -10622,6 +10462,14 @@
 						"dom-serializer": "0",
 						"domelementtype": "1"
 					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -10635,13 +10483,10 @@
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"requires": {
-				"is-finite": "^1.0.0"
-			}
+		"replace-ext": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
 		"request": {
 			"version": "2.88.0",
@@ -10668,24 +10513,40 @@
 				"tough-cookie": "~2.4.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
 			"requires": {
-				"lodash": "^4.13.1"
+				"lodash": "^4.17.11"
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
 			"requires": {
-				"request-promise-core": "1.1.1",
-				"stealthy-require": "^1.1.0",
-				"tough-cookie": ">=2.3.3"
+				"request-promise-core": "1.1.2",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
 			}
 		},
 		"require-directory": {
@@ -10699,18 +10560,14 @@
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"require-main-filename": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
 		},
-		"require-uncached": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
-			}
+		"requireindex": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
 		},
 		"requires-port": {
 			"version": "1.0.0",
@@ -10718,11 +10575,11 @@
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "^1.0.6"
 			}
 		},
 		"resolve-cwd": {
@@ -10731,28 +10588,12 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"requires": {
 				"resolve-from": "^3.0.0"
-			},
-			"dependencies": {
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-				}
-			}
-		},
-		"resolve-dir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-			"requires": {
-				"expand-tilde": "^2.0.0",
-				"global-modules": "^1.0.0"
 			}
 		},
 		"resolve-from": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
@@ -10784,11 +10625,11 @@
 			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
 		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "^7.1.3"
 			}
 		},
 		"ripemd160": {
@@ -10801,9 +10642,9 @@
 			}
 		},
 		"rsvp": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+			"integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA=="
 		},
 		"run-async": {
 			"version": "2.3.0",
@@ -10822,9 +10663,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.3.3",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-			"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+			"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -10836,7 +10677,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
 				"ret": "~0.1.10"
@@ -10848,278 +10689,19 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
-			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+			"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
 			"requires": {
+				"@cnakazawa/watch": "^1.0.3",
 				"anymatch": "^2.0.0",
-				"capture-exit": "^1.2.0",
-				"exec-sh": "^0.2.0",
+				"capture-exit": "^2.0.0",
+				"exec-sh": "^0.3.2",
+				"execa": "^1.0.0",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.3",
 				"micromatch": "^3.1.4",
 				"minimist": "^1.1.1",
-				"walker": "~1.0.5",
-				"watch": "~0.18.0"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"watch": {
-					"version": "0.18.0",
-					"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
-					"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-					"requires": {
-						"exec-sh": "^0.2.0",
-						"minimist": "^1.2.0"
-					}
-				}
+				"walker": "~1.0.5"
 			}
 		},
 		"sass-loader": {
@@ -11159,10 +10741,10 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
 					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				},
 				"shallow-clone": {
 					"version": "1.0.0",
@@ -11189,9 +10771,9 @@
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"saxes": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.3.tgz",
-			"integrity": "sha512-Nc5DXc5A+m3rUDtkS+vHlBWKT7mCKjJPyia7f8YMW773hsXVv2wEHQZGE0zs4+5PLwz9U5Sbl/94Cnd9vHV7Bg==",
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.9.tgz",
+			"integrity": "sha512-FZeKhJglhJHk7eWG5YM0z46VHmI3KJpMBAQm3xa9meDvd+wevB5GuBB0wc0exPInZiBBHqi00DbS8AcvCGCFMw==",
 			"requires": {
 				"xmlchars": "^1.3.1"
 			}
@@ -11213,29 +10795,6 @@
 				"ajv": "^6.1.0",
 				"ajv-errors": "^1.0.0",
 				"ajv-keywords": "^3.1.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-					"integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-				},
-				"json-schema-traverse": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-				}
 			}
 		},
 		"select-hose": {
@@ -11252,14 +10811,14 @@
 			}
 		},
 		"semver": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+			"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
 		},
 		"send": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
 			"requires": {
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
@@ -11268,25 +10827,40 @@
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
+				"http-errors": "~1.7.2",
+				"mime": "1.6.0",
+				"ms": "2.1.1",
 				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
+				"range-parser": "~1.2.1",
+				"statuses": "~1.5.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+						}
+					}
+				},
 				"mime": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 				}
 			}
 		},
 		"serialize-javascript": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
+			"integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA=="
 		},
 		"serve-index": {
 			"version": "1.9.1",
@@ -11300,17 +10874,48 @@
 				"http-errors": "~1.6.2",
 				"mime-types": "~2.1.17",
 				"parseurl": "~1.3.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"http-errors": {
+					"version": "1.6.3",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.0",
+						"statuses": ">= 1.4.0 < 2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+				}
 			}
 		},
 		"serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
 			"requires": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
-				"send": "0.16.2"
+				"parseurl": "~1.3.3",
+				"send": "0.17.1"
 			}
 		},
 		"set-blocking": {
@@ -11345,13 +10950,13 @@
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
 		},
 		"sha.js": {
 			"version": "2.4.11",
-			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
 				"inherits": "^2.0.1",
@@ -11369,9 +10974,14 @@
 				"mixin-object": "^2.0.1"
 			},
 			"dependencies": {
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+				},
 				"kind-of": {
 					"version": "2.0.1",
-					"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 					"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 					"requires": {
 						"is-buffer": "^1.0.2"
@@ -11439,20 +11049,22 @@
 			"integrity": "sha512-XQdzyPAjHeqcBDJfUBKgfnurtE9Z/PC7Jh73DAiNlS4vMkdVTrtNpg5GJEGSDOtJ5LPQdZ/BWTx5GNzsP89mlA=="
 		},
 		"sisteransi": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
-			"integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+			"integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ=="
 		},
 		"slash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
 		},
 		"slice-ansi": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+			"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
 			"requires": {
+				"ansi-styles": "^3.2.0",
+				"astral-regex": "^1.0.0",
 				"is-fullwidth-code-point": "^2.0.0"
 			}
 		},
@@ -11471,6 +11083,14 @@
 				"use": "^3.1.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -11487,10 +11107,10 @@
 						"is-extendable": "^0.1.0"
 					}
 				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -11573,16 +11193,26 @@
 			}
 		},
 		"sockjs-client": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
-			"integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
+			"integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
 			"requires": {
-				"debug": "^2.6.6",
-				"eventsource": "0.1.6",
-				"faye-websocket": "~0.11.0",
-				"inherits": "^2.0.1",
+				"debug": "^3.2.5",
+				"eventsource": "^1.0.7",
+				"faye-websocket": "~0.11.1",
+				"inherits": "^2.0.3",
 				"json3": "^3.3.2",
-				"url-parse": "^1.1.8"
+				"url-parse": "^1.4.3"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
 			}
 		},
 		"source-list-map": {
@@ -11591,9 +11221,9 @@
 			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
 		},
 		"source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-resolve": {
 			"version": "0.5.2",
@@ -11608,17 +11238,18 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.4.18",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"version": "0.5.12",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+			"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
 			"requires": {
-				"source-map": "^0.5.6"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			},
 			"dependencies": {
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -11627,10 +11258,15 @@
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
+		"space-separated-tokens": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz",
+			"integrity": "sha512-UyhMSmeIqZrQn2UdjYpxEkwY9JUrn8pP+7L4f91zRzOQuI8MF1FGLfYU9DKCYeLdo7LXMxwrX5zKFy7eeeVHuA=="
+		},
 		"spdx-correct": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -11651,35 +11287,45 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-			"integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+			"integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
 		},
 		"spdy": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
-			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
+			"integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
 			"requires": {
-				"debug": "^2.6.8",
-				"handle-thing": "^1.2.5",
+				"debug": "^4.1.0",
+				"handle-thing": "^2.0.0",
 				"http-deceiver": "^1.2.7",
-				"safe-buffer": "^5.0.1",
 				"select-hose": "^2.0.0",
-				"spdy-transport": "^2.0.18"
+				"spdy-transport": "^3.0.0"
 			}
 		},
 		"spdy-transport": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
-			"integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+			"integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
 			"requires": {
-				"debug": "^2.6.8",
-				"detect-node": "^2.0.3",
+				"debug": "^4.1.0",
+				"detect-node": "^2.0.4",
 				"hpack.js": "^2.1.6",
-				"obuf": "^1.1.1",
-				"readable-stream": "^2.2.9",
-				"safe-buffer": "^5.0.1",
-				"wbuf": "^1.7.2"
+				"obuf": "^1.1.2",
+				"readable-stream": "^3.0.6",
+				"wbuf": "^1.7.3"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"split-string": {
@@ -11696,9 +11342,9 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
-			"integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -11725,9 +11371,9 @@
 			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
 		},
 		"stack-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -11749,9 +11395,9 @@
 			}
 		},
 		"statuses": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
@@ -11759,9 +11405,9 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
 		"stream-browserify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+			"integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
@@ -11800,21 +11446,6 @@
 			"requires": {
 				"astral-regex": "^1.0.0",
 				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
 			}
 		},
 		"string-width": {
@@ -11824,21 +11455,6 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
 			}
 		},
 		"string_decoder": {
@@ -11860,20 +11476,17 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "^3.0.0"
 			}
 		},
 		"strip-bom": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"requires": {
-				"is-utf8": "^0.2.0"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
 		"strip-comments": {
 			"version": "1.0.2",
@@ -11886,7 +11499,7 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-json-comments": {
@@ -11895,66 +11508,24 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"style-loader": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.0.tgz",
-			"integrity": "sha512-uCcN7XWHkqwGVt7skpInW6IGO1tG6ReyFQ1Cseh0VcN6VdcFQi62aG/2F3Y9ueA8x4IVlfaSUxpmQXQD9QrEuQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
+			"integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
 			"requires": {
 				"loader-utils": "^1.1.0",
-				"schema-utils": "^0.4.5"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-					"integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-				},
-				"json-schema-traverse": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-				},
-				"schema-utils": {
-					"version": "0.4.7",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				}
+				"schema-utils": "^1.0.0"
 			}
 		},
 		"stylehacks": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.1.tgz",
-			"integrity": "sha512-TK5zEPeD9NyC1uPIdjikzsgWxdQQN/ry1X3d1iOz1UkYDCmcr928gWD1KHgyC27F50UnE0xCTrBOO1l6KR8M4w==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
+			"integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
 			"requires": {
 				"browserslist": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-selector-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-					"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
-					}
-				},
 				"postcss-selector-parser": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -11976,22 +11547,22 @@
 			}
 		},
 		"svgo": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.1.1.tgz",
-			"integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
+			"integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
 			"requires": {
-				"coa": "~2.0.1",
-				"colors": "~1.1.2",
+				"chalk": "^2.4.1",
+				"coa": "^2.0.2",
 				"css-select": "^2.0.0",
-				"css-select-base-adapter": "~0.1.0",
+				"css-select-base-adapter": "^0.1.1",
 				"css-tree": "1.0.0-alpha.28",
 				"css-url-regex": "^1.1.0",
-				"csso": "^3.5.0",
-				"js-yaml": "^3.12.0",
+				"csso": "^3.5.1",
+				"js-yaml": "^3.13.1",
 				"mkdirp": "~0.5.1",
-				"object.values": "^1.0.4",
+				"object.values": "^1.1.0",
 				"sax": "~1.2.4",
-				"stable": "~0.1.6",
+				"stable": "^0.1.8",
 				"unquote": "~1.1.1",
 				"util.promisify": "~1.0.0"
 			}
@@ -12002,150 +11573,94 @@
 			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
 		},
 		"table": {
-			"version": "4.0.3",
-			"resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
-			"integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
+			"integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
 			"requires": {
-				"ajv": "^6.0.1",
-				"ajv-keywords": "^3.0.0",
-				"chalk": "^2.1.0",
-				"lodash": "^4.17.4",
-				"slice-ansi": "1.0.0",
-				"string-width": "^2.1.1"
+				"ajv": "^6.9.1",
+				"lodash": "^4.17.11",
+				"slice-ansi": "^2.1.0",
+				"string-width": "^3.0.0"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-					"integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
 					}
 				},
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-				},
-				"json-schema-traverse": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
 				}
 			}
 		},
 		"tapable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
-			"integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
 		},
 		"terser": {
-			"version": "3.10.3",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.10.3.tgz",
-			"integrity": "sha512-uyL5hwDICjnv49JANhZvQYLikt/HADWNbUFsKQpZ/i+JSOkL2T4V7WUpW7S/5QGZceVq2x0HRVhEQQuW2ZpX6g==",
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
 			"requires": {
-				"commander": "~2.17.1",
+				"commander": "^2.19.0",
 				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.6"
+				"source-map-support": "~0.5.10"
 			},
 			"dependencies": {
-				"source-map-support": {
-					"version": "0.5.9",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.1.0.tgz",
-			"integrity": "sha512-61lV0DSxMAZ8AyZG7/A4a3UPlrbOBo8NIQ4tJzLPAdGOQ+yoNC7l5ijEow27lBAL2humer01KLS6bGIMYQxKoA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
+			"integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
 			"requires": {
 				"cacache": "^11.0.2",
 				"find-cache-dir": "^2.0.0",
 				"schema-utils": "^1.0.0",
 				"serialize-javascript": "^1.4.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.8.1",
+				"terser": "^3.16.1",
 				"webpack-sources": "^1.1.0",
 				"worker-farm": "^1.5.2"
 			},
 			"dependencies": {
-				"find-cache-dir": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
-					"integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^1.0.0",
-						"pkg-dir": "^3.0.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"requires": {
-						"find-up": "^3.0.0"
-					}
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"test-exclude": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
-			"integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+			"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
 			"requires": {
-				"arrify": "^1.0.1",
-				"micromatch": "^2.3.11",
-				"object-assign": "^4.1.0",
-				"read-pkg-up": "^1.0.1",
-				"require-main-filename": "^1.0.1"
+				"glob": "^7.1.3",
+				"minimatch": "^3.0.4",
+				"read-pkg-up": "^4.0.0",
+				"require-main-filename": "^2.0.0"
 			}
 		},
 		"text-table": {
@@ -12164,11 +11679,11 @@
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
 			"requires": {
-				"readable-stream": "^2.1.5",
+				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
 			}
 		},
@@ -12239,40 +11754,20 @@
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				}
 			}
 		},
-		"topo": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-			"integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-			"requires": {
-				"hoek": "4.x.x"
-			}
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
 		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-				}
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
 			}
 		},
 		"tr46": {
@@ -12288,15 +11783,28 @@
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
-		"tryer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+		"trough": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
+			"integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q=="
+		},
+		"ts-pnp": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.2.tgz",
+			"integrity": "sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA=="
 		},
 		"tslib": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
 			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+		},
+		"tsutils": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.11.0.tgz",
+			"integrity": "sha512-RRtGX1FVfHm1+P9XVqN+RxqUa8ZCZ2LjaPyaRUQH7Wvn9cYAkpz/cZKy+BWU/+fncFqjW/+PVgRWF4Ky5IGbjQ==",
+			"requires": {
+				"tslib": "^1.8.1"
+			}
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
@@ -12325,12 +11833,12 @@
 			}
 		},
 		"type-is": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "~2.1.18"
+				"mime-types": "~2.1.24"
 			}
 		},
 		"typedarray": {
@@ -12344,131 +11852,23 @@
 			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
 		},
 		"uglify-js": {
-			"version": "3.4.9",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+			"version": "3.4.10",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
+			"integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
 			"requires": {
-				"commander": "~2.17.1",
+				"commander": "~2.19.0",
 				"source-map": "~0.6.1"
-			}
-		},
-		"uglifyjs-webpack-plugin": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
-			"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
-			"requires": {
-				"cacache": "^10.0.4",
-				"find-cache-dir": "^1.0.0",
-				"schema-utils": "^0.4.5",
-				"serialize-javascript": "^1.4.0",
-				"source-map": "^0.6.1",
-				"uglify-es": "^3.3.4",
-				"webpack-sources": "^1.1.0",
-				"worker-farm": "^1.5.2"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-					"integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"cacache": {
-					"version": "10.0.4",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-					"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
-					"requires": {
-						"bluebird": "^3.5.1",
-						"chownr": "^1.0.1",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"lru-cache": "^4.1.1",
-						"mississippi": "^2.0.0",
-						"mkdirp": "^0.5.1",
-						"move-concurrently": "^1.0.1",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^2.6.2",
-						"ssri": "^5.2.4",
-						"unique-filename": "^1.1.0",
-						"y18n": "^4.0.0"
-					}
-				},
 				"commander": {
-					"version": "2.13.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+					"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
 				},
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-				},
-				"json-schema-traverse": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-				},
-				"mississippi": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
-					"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
-					"requires": {
-						"concat-stream": "^1.5.0",
-						"duplexify": "^3.4.2",
-						"end-of-stream": "^1.1.0",
-						"flush-write-stream": "^1.0.0",
-						"from2": "^2.1.0",
-						"parallel-transform": "^1.1.0",
-						"pump": "^2.0.1",
-						"pumpify": "^1.3.3",
-						"stream-each": "^1.1.0",
-						"through2": "^2.0.0"
-					}
-				},
-				"pump": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"schema-utils": {
-					"version": "0.4.7",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				},
-				"ssri": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-					"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-					"requires": {
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"uglify-es": {
-					"version": "3.3.9",
-					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-					"requires": {
-						"commander": "~2.13.0",
-						"source-map": "~0.6.1"
-					}
-				},
-				"y18n": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -12487,14 +11887,42 @@
 			}
 		},
 		"unicode-match-property-value-ecmascript": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
 		},
 		"unicode-property-aliases-ecmascript": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
+		},
+		"unified": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+			"integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+			"requires": {
+				"@types/unist": "^2.0.0",
+				"@types/vfile": "^3.0.0",
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^3.0.0",
+				"x-is-string": "^0.1.0"
+			},
+			"dependencies": {
+				"vfile": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+					"integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+					"requires": {
+						"is-buffer": "^2.0.0",
+						"replace-ext": "1.0.0",
+						"unist-util-stringify-position": "^1.0.0",
+						"vfile-message": "^1.0.0"
+					}
+				}
+			}
 		},
 		"union-value": {
 			"version": "1.0.0",
@@ -12554,6 +11982,11 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
+		"unist-util-stringify-position": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -12606,9 +12039,9 @@
 			}
 		},
 		"upath": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q=="
 		},
 		"upper-case": {
 			"version": "1.1.3",
@@ -12645,9 +12078,9 @@
 			}
 		},
 		"url-loader": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.1.tgz",
-			"integrity": "sha512-vugEeXjyYFBCUOpX+ZuaunbK3QXMKaQ3zUnRfIpRBlGkY7QizCnzyyn2ASfcxsvyU3ef+CJppVywnl3Kgf13Gg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
+			"integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
 			"requires": {
 				"loader-utils": "^1.1.0",
 				"mime": "^2.0.3",
@@ -12655,11 +12088,11 @@
 			}
 		},
 		"url-parse": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
-			"integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+			"integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
 			"requires": {
-				"querystringify": "^2.0.0",
+				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
 			}
 		},
@@ -12674,9 +12107,9 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
 		"util": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+			"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
 			"requires": {
 				"inherits": "2.0.3"
 			}
@@ -12725,9 +12158,9 @@
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"vendors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
-			"integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
+			"integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw=="
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -12737,6 +12170,52 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
+			}
+		},
+		"vfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.0.tgz",
+			"integrity": "sha512-WMNeHy5djSl895BqE86D7WqA0Ie5fAIeGCa7V1EqiXyJg5LaGch2SUaZueok5abYQGH6mXEAsZ45jkoILIOlyA==",
+			"requires": {
+				"@types/unist": "^2.0.2",
+				"is-buffer": "^2.0.0",
+				"replace-ext": "1.0.0",
+				"unist-util-stringify-position": "^2.0.0",
+				"vfile-message": "^2.0.0"
+			},
+			"dependencies": {
+				"unist-util-stringify-position": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz",
+					"integrity": "sha512-Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==",
+					"requires": {
+						"@types/unist": "^2.0.2"
+					}
+				},
+				"vfile-message": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.0.tgz",
+					"integrity": "sha512-YS6qg6UpBfIeiO+6XlhPOuJaoLvt1Y9g2cmlwqhBOOU0XRV8j5RLeoz72t6PWLvNXq3EBG1fQ05wNPrUoz0deQ==",
+					"requires": {
+						"@types/unist": "^2.0.2",
+						"unist-util-stringify-position": "^1.1.1"
+					},
+					"dependencies": {
+						"unist-util-stringify-position": {
+							"version": "1.1.2",
+							"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+							"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+						}
+					}
+				}
+			}
+		},
+		"vfile-message": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+			"requires": {
+				"unist-util-stringify-position": "^1.1.1"
 			}
 		},
 		"vm-browserify": {
@@ -12753,6 +12232,16 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"requires": {
 				"browser-process-hrtime": "^0.1.2"
+			}
+		},
+		"w3c-xmlserializer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+			"integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+			"requires": {
+				"domexception": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"xml-name-validator": "^3.0.0"
 			}
 		},
 		"walker": {
@@ -12781,6 +12270,11 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
+		"web-namespaces": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.3.tgz",
+			"integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA=="
+		},
 		"web-speech-cognitive-services": {
 			"version": "2.1.1-master.0f7758b",
 			"resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-2.1.1-master.0f7758b.tgz",
@@ -12806,16 +12300,16 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "4.19.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.19.1.tgz",
-			"integrity": "sha512-j7Q/5QqZRqIFXJvC0E59ipLV5Hf6lAnS3ezC3I4HMUybwEDikQBVad5d+IpPtmaQPQArvgUZLXIN6lWijHBn4g==",
+			"version": "4.29.6",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.6.tgz",
+			"integrity": "sha512-MwBwpiE1BQpMDkbnUUaW6K8RFZjljJHArC6tWQJoFm0oQtfoSebtg4Y7/QHnJ/SddtjYLHaKGX64CFjG5rehJw==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.6",
-				"@webassemblyjs/helper-module-context": "1.7.6",
-				"@webassemblyjs/wasm-edit": "1.7.6",
-				"@webassemblyjs/wasm-parser": "1.7.6",
-				"acorn": "^5.6.2",
-				"acorn-dynamic-import": "^3.0.0",
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-module-context": "1.8.5",
+				"@webassemblyjs/wasm-edit": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5",
+				"acorn": "^6.0.5",
+				"acorn-dynamic-import": "^4.0.0",
 				"ajv": "^6.1.0",
 				"ajv-keywords": "^3.1.0",
 				"chrome-trace-event": "^1.0.0",
@@ -12829,325 +12323,41 @@
 				"mkdirp": "~0.5.0",
 				"neo-async": "^2.5.0",
 				"node-libs-browser": "^2.0.0",
-				"schema-utils": "^0.4.4",
+				"schema-utils": "^1.0.0",
 				"tapable": "^1.1.0",
-				"uglifyjs-webpack-plugin": "^1.2.4",
+				"terser-webpack-plugin": "^1.1.0",
 				"watchpack": "^1.5.0",
-				"webpack-sources": "^1.2.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-					"integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"eslint-scope": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-					"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"json-schema-traverse": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				},
-				"schema-utils": {
-					"version": "0.4.7",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				}
+				"webpack-sources": "^1.3.0"
 			}
 		},
 		"webpack-dev-middleware": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
-			"integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
+			"integrity": "sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==",
 			"requires": {
-				"memory-fs": "~0.4.1",
-				"mime": "^2.3.1",
-				"range-parser": "^1.0.3",
+				"memory-fs": "^0.4.1",
+				"mime": "^2.4.2",
+				"range-parser": "^1.2.1",
 				"webpack-log": "^2.0.0"
 			}
 		},
 		"webpack-dev-server": {
-			"version": "3.1.9",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.9.tgz",
-			"integrity": "sha512-fqPkuNalLuc/hRC2QMkVYJkgNmRvxZQo7ykA2e1XRg/tMJm3qY7ZaD6d89/Fqjxtj9bOrn5wZzLD2n84lJdvWg==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.2.1.tgz",
+			"integrity": "sha512-sjuE4mnmx6JOh9kvSbPYw3u/6uxCLHNWfhWaIPwcXWsvWOPN+nc5baq4i9jui3oOBRXGonK9+OI0jVkaz6/rCw==",
 			"requires": {
 				"ansi-html": "0.0.7",
 				"bonjour": "^3.5.0",
 				"chokidar": "^2.0.0",
 				"compression": "^1.5.2",
 				"connect-history-api-fallback": "^1.3.0",
-				"debug": "^3.1.0",
+				"debug": "^4.1.1",
 				"del": "^3.0.0",
 				"express": "^4.16.2",
 				"html-entities": "^1.2.0",
-				"http-proxy-middleware": "~0.18.0",
+				"http-proxy-middleware": "^0.19.1",
 				"import-local": "^2.0.0",
-				"internal-ip": "^3.0.1",
+				"internal-ip": "^4.2.0",
 				"ip": "^1.1.5",
 				"killable": "^1.0.0",
 				"loglevel": "^1.4.1",
@@ -13155,54 +12365,28 @@
 				"portfinder": "^1.0.9",
 				"schema-utils": "^1.0.0",
 				"selfsigned": "^1.9.1",
+				"semver": "^5.6.0",
 				"serve-index": "^1.7.2",
 				"sockjs": "0.3.19",
-				"sockjs-client": "1.1.5",
-				"spdy": "^3.4.1",
+				"sockjs-client": "1.3.0",
+				"spdy": "^4.0.0",
 				"strip-ansi": "^3.0.0",
-				"supports-color": "^5.1.0",
-				"webpack-dev-middleware": "3.4.0",
+				"supports-color": "^6.1.0",
+				"url": "^0.11.0",
+				"webpack-dev-middleware": "^3.5.1",
 				"webpack-log": "^2.0.0",
 				"yargs": "12.0.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"cliui": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
 				},
 				"decamelize": {
 					"version": "2.0.0",
@@ -13212,154 +12396,31 @@
 						"xregexp": "4.0.0"
 					}
 				},
-				"del": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-					"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-					"requires": {
-						"globby": "^6.1.0",
-						"is-path-cwd": "^1.0.0",
-						"is-path-in-cwd": "^1.0.0",
-						"p-map": "^1.1.1",
-						"pify": "^3.0.0",
-						"rimraf": "^2.2.8"
-					}
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 				},
-				"execa": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"globby": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-						}
-					}
-				},
-				"import-local": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-					"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-					"requires": {
-						"pkg-dir": "^3.0.0",
-						"resolve-cwd": "^2.0.0"
-					}
-				},
-				"invert-kv": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
-				},
-				"lcid": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-					"requires": {
-						"invert-kv": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"mem": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
-					"integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
-					"requires": {
-						"map-age-cleaner": "^0.1.1",
-						"mimic-fn": "^1.0.0",
-						"p-is-promise": "^1.1.0"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				},
-				"os-locale": {
+				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-					"integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
-						"execa": "^0.10.0",
-						"lcid": "^2.0.0",
-						"mem": "^4.0.0"
+						"ansi-regex": "^2.0.0"
 					}
 				},
-				"p-limit": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"requires": {
-						"p-try": "^2.0.0"
+						"has-flag": "^3.0.0"
 					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				},
-				"xregexp": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-					"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
 				},
 				"yargs": {
 					"version": "12.0.2",
@@ -13416,6 +12477,13 @@
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"websocket-driver": {
@@ -13446,14 +12514,14 @@
 			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"whatwg-mimetype": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz",
-			"integrity": "sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
 		},
 		"whatwg-url": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-			"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
 			"requires": {
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.1",
@@ -13479,48 +12547,49 @@
 			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 		},
 		"workbox-background-sync": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.6.3.tgz",
-			"integrity": "sha512-ypLo0B6dces4gSpaslmDg5wuoUWrHHVJfFWwl1udvSylLdXvnrfhFfriCS42SNEe5lsZtcNZF27W/SMzBlva7Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-4.3.1.tgz",
+			"integrity": "sha512-1uFkvU8JXi7L7fCHVBEEnc3asPpiAL33kO495UMcD5+arew9IbKW2rV5lpzhoWcm/qhGB89YfO4PmB/0hQwPRg==",
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
-		"workbox-broadcast-cache-update": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.6.3.tgz",
-			"integrity": "sha512-pJl4lbClQcvp0SyTiEw0zLSsVYE1RDlCPtpKnpMjxFtu8lCFTAEuVyzxp9w7GF4/b3P4h5nyQ+q7V9mIR7YzGg==",
+		"workbox-broadcast-update": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-4.3.1.tgz",
+			"integrity": "sha512-MTSfgzIljpKLTBPROo4IpKjESD86pPFlZwlvVG32Kb70hW+aob4Jxpblud8EhNb1/L5m43DUM4q7C+W6eQMMbA==",
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-build": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.6.3.tgz",
-			"integrity": "sha512-w0clZ/pVjL8VXy6GfthefxpEXs0T8uiRuopZSFVQ8ovfbH6c6kUpEh6DcYwm/Y6dyWPiCucdyAZotgjz+nRz8g==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-4.3.1.tgz",
+			"integrity": "sha512-UHdwrN3FrDvicM3AqJS/J07X0KXj67R8Cg0waq1MKEOqzo89ap6zh6LmaLnRAjpB+bDIz+7OlPye9iii9KBnxw==",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"common-tags": "^1.4.0",
+				"@babel/runtime": "^7.3.4",
+				"@hapi/joi": "^15.0.0",
+				"common-tags": "^1.8.0",
 				"fs-extra": "^4.0.2",
-				"glob": "^7.1.2",
-				"joi": "^11.1.1",
+				"glob": "^7.1.3",
 				"lodash.template": "^4.4.0",
-				"pretty-bytes": "^4.0.2",
-				"stringify-object": "^3.2.2",
+				"pretty-bytes": "^5.1.0",
+				"stringify-object": "^3.3.0",
 				"strip-comments": "^1.0.2",
-				"workbox-background-sync": "^3.6.3",
-				"workbox-broadcast-cache-update": "^3.6.3",
-				"workbox-cache-expiration": "^3.6.3",
-				"workbox-cacheable-response": "^3.6.3",
-				"workbox-core": "^3.6.3",
-				"workbox-google-analytics": "^3.6.3",
-				"workbox-navigation-preload": "^3.6.3",
-				"workbox-precaching": "^3.6.3",
-				"workbox-range-requests": "^3.6.3",
-				"workbox-routing": "^3.6.3",
-				"workbox-strategies": "^3.6.3",
-				"workbox-streams": "^3.6.3",
-				"workbox-sw": "^3.6.3"
+				"workbox-background-sync": "^4.3.1",
+				"workbox-broadcast-update": "^4.3.1",
+				"workbox-cacheable-response": "^4.3.1",
+				"workbox-core": "^4.3.1",
+				"workbox-expiration": "^4.3.1",
+				"workbox-google-analytics": "^4.3.1",
+				"workbox-navigation-preload": "^4.3.1",
+				"workbox-precaching": "^4.3.1",
+				"workbox-range-requests": "^4.3.1",
+				"workbox-routing": "^4.3.1",
+				"workbox-strategies": "^4.3.1",
+				"workbox-streams": "^4.3.1",
+				"workbox-sw": "^4.3.1",
+				"workbox-window": "^4.3.1"
 			},
 			"dependencies": {
 				"fs-extra": {
@@ -13535,118 +12604,139 @@
 				}
 			}
 		},
-		"workbox-cache-expiration": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.6.3.tgz",
-			"integrity": "sha512-+ECNph/6doYx89oopO/UolYdDmQtGUgo8KCgluwBF/RieyA1ZOFKfrSiNjztxOrGJoyBB7raTIOlEEwZ1LaHoA==",
-			"requires": {
-				"workbox-core": "^3.6.3"
-			}
-		},
 		"workbox-cacheable-response": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.6.3.tgz",
-			"integrity": "sha512-QpmbGA9SLcA7fklBLm06C4zFg577Dt8u3QgLM0eMnnbaVv3rhm4vbmDpBkyTqvgK/Ly8MBDQzlXDtUCswQwqqg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-4.3.1.tgz",
+			"integrity": "sha512-Rp5qlzm6z8IOvnQNkCdO9qrDgDpoPNguovs0H8C+wswLuPgSzSp9p2afb5maUt9R1uTIwOXrVQMmPfPypv+npw==",
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-core": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.6.3.tgz",
-			"integrity": "sha512-cx9cx0nscPkIWs8Pt98HGrS9/aORuUcSkWjG25GqNWdvD/pSe7/5Oh3BKs0fC+rUshCiyLbxW54q0hA+GqZeSQ=="
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-4.3.1.tgz",
+			"integrity": "sha512-I3C9jlLmMKPxAC1t0ExCq+QoAMd0vAAHULEgRZ7kieCdUd919n53WC0AfvokHNwqRhGn+tIIj7vcb5duCjs2Kg=="
+		},
+		"workbox-expiration": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-4.3.1.tgz",
+			"integrity": "sha512-vsJLhgQsQouv9m0rpbXubT5jw0jMQdjpkum0uT+d9tTwhXcEZks7qLfQ9dGSaufTD2eimxbUOJfWLbNQpIDMPw==",
+			"requires": {
+				"workbox-core": "^4.3.1"
+			}
 		},
 		"workbox-google-analytics": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.6.3.tgz",
-			"integrity": "sha512-RQBUo/6SXtIaQTRFj4RQZ9e1gAl7D8oS5S+Hi173Kk70/BgJjzPwXpC5A249Jv5YfkCOLMQCeF9A27BiD0b0ig==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-4.3.1.tgz",
+			"integrity": "sha512-xzCjAoKuOb55CBSwQrbyWBKqp35yg1vw9ohIlU2wTy06ZrYfJ8rKochb1MSGlnoBfXGWss3UPzxR5QL5guIFdg==",
 			"requires": {
-				"workbox-background-sync": "^3.6.3",
-				"workbox-core": "^3.6.3",
-				"workbox-routing": "^3.6.3",
-				"workbox-strategies": "^3.6.3"
+				"workbox-background-sync": "^4.3.1",
+				"workbox-core": "^4.3.1",
+				"workbox-routing": "^4.3.1",
+				"workbox-strategies": "^4.3.1"
 			}
 		},
 		"workbox-navigation-preload": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-3.6.3.tgz",
-			"integrity": "sha512-dd26xTX16DUu0i+MhqZK/jQXgfIitu0yATM4jhRXEmpMqQ4MxEeNvl2CgjDMOHBnCVMax+CFZQWwxMx/X/PqCw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-4.3.1.tgz",
+			"integrity": "sha512-K076n3oFHYp16/C+F8CwrRqD25GitA6Rkd6+qAmLmMv1QHPI2jfDwYqrytOfKfYq42bYtW8Pr21ejZX7GvALOw==",
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-precaching": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.6.3.tgz",
-			"integrity": "sha512-aBqT66BuMFviPTW6IpccZZHzpA8xzvZU2OM1AdhmSlYDXOJyb1+Z6blVD7z2Q8VNtV1UVwQIdImIX+hH3C3PIw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-4.3.1.tgz",
+			"integrity": "sha512-piSg/2csPoIi/vPpp48t1q5JLYjMkmg5gsXBQkh/QYapCdVwwmKlU9mHdmy52KsDGIjVaqEUMFvEzn2LRaigqQ==",
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-range-requests": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.6.3.tgz",
-			"integrity": "sha512-R+yLWQy7D9aRF9yJ3QzwYnGFnGDhMUij4jVBUVtkl67oaVoP1ymZ81AfCmfZro2kpPRI+vmNMfxxW531cqdx8A==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-4.3.1.tgz",
+			"integrity": "sha512-S+HhL9+iTFypJZ/yQSl/x2Bf5pWnbXdd3j57xnb0V60FW1LVn9LRZkPtneODklzYuFZv7qK6riZ5BNyc0R0jZA==",
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-routing": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.6.3.tgz",
-			"integrity": "sha512-bX20i95OKXXQovXhFOViOK63HYmXvsIwZXKWbSpVeKToxMrp0G/6LZXnhg82ijj/S5yhKNRf9LeGDzaqxzAwMQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-4.3.1.tgz",
+			"integrity": "sha512-FkbtrODA4Imsi0p7TW9u9MXuQ5P4pVs1sWHK4dJMMChVROsbEltuE79fBoIk/BCztvOJ7yUpErMKa4z3uQLX+g==",
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-strategies": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.6.3.tgz",
-			"integrity": "sha512-Pg5eulqeKet2y8j73Yw6xTgLdElktcWExGkzDVCGqfV9JCvnGuEpz5eVsCIK70+k4oJcBCin9qEg3g3CwEIH3g==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-4.3.1.tgz",
+			"integrity": "sha512-F/+E57BmVG8dX6dCCopBlkDvvhg/zj6VDs0PigYwSN23L8hseSRwljrceU2WzTvk/+BSYICsWmRq5qHS2UYzhw==",
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-streams": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.6.3.tgz",
-			"integrity": "sha512-rqDuS4duj+3aZUYI1LsrD2t9hHOjwPqnUIfrXSOxSVjVn83W2MisDF2Bj+dFUZv4GalL9xqErcFW++9gH+Z27w==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-4.3.1.tgz",
+			"integrity": "sha512-4Kisis1f/y0ihf4l3u/+ndMkJkIT4/6UOacU3A4BwZSAC9pQ9vSvJpIi/WFGQRH/uPXvuVjF5c2RfIPQFSS2uA==",
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-sw": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.6.3.tgz",
-			"integrity": "sha512-IQOUi+RLhvYCiv80RP23KBW/NTtIvzvjex28B8NW1jOm+iV4VIu3VXKXTA6er5/wjjuhmtB28qEAUqADLAyOSg=="
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-4.3.1.tgz",
+			"integrity": "sha512-0jXdusCL2uC5gM3yYFT6QMBzKfBr2XTk0g5TPAV4y8IZDyVNDyj1a8uSXy3/XrvkVTmQvLN4O5k3JawGReXr9w=="
 		},
 		"workbox-webpack-plugin": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-3.6.2.tgz",
-			"integrity": "sha512-FGSkcaiMDM41uTGkYf7O6hf2W7UvkNc+iUIltfGiRp+qeQfXKOOh5fJCz+a6AFkeuGELSSYROsQRuOqX8LytcQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-4.2.0.tgz",
+			"integrity": "sha512-YZsiA+y/ns/GdWRaBsfYv8dln1ebWtGnJcTOg1ppO0pO1tScAHX0yGtHIjndxz3L/UUhE8b0NQE9KeLNwJwA5A==",
 			"requires": {
-				"babel-runtime": "^6.26.0",
+				"@babel/runtime": "^7.0.0",
 				"json-stable-stringify": "^1.0.1",
-				"workbox-build": "^3.6.2"
+				"workbox-build": "^4.2.0"
+			}
+		},
+		"workbox-window": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-4.3.1.tgz",
+			"integrity": "sha512-C5gWKh6I58w3GeSc0wp2Ne+rqVw8qwcmZnQGpjiek8A2wpbxSJb1FdCoQVO+jDJs35bFgo/WETgl1fqgsxN0Hg==",
+			"requires": {
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"worker-farm": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+			"integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
 			"requires": {
 				"errno": "~0.1.7"
 			}
 		},
+		"worker-rpc": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.1.1.tgz",
+			"integrity": "sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==",
+			"requires": {
+				"microevent.ts": "~0.1.1"
+			}
+		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -13664,6 +12754,14 @@
 						"is-fullwidth-code-point": "^1.0.0",
 						"strip-ansi": "^3.0.0"
 					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -13673,17 +12771,17 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
 			"requires": {
 				"mkdirp": "^0.5.1"
 			}
 		},
 		"write-file-atomic": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -13691,12 +12789,17 @@
 			}
 		},
 		"ws": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.0.tgz",
-			"integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
 			"requires": {
 				"async-limiter": "~1.0.0"
 			}
+		},
+		"x-is-string": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",
@@ -13708,88 +12811,59 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
 			"integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw=="
 		},
+		"xregexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
+		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 		},
 		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 		},
 		"yargs": {
-			"version": "11.1.0",
-			"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
 			"requires": {
 				"cliui": "^4.0.0",
-				"decamelize": "^1.1.1",
-				"find-up": "^2.1.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
 				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
+				"os-locale": "^3.0.0",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^1.0.1",
 				"set-blocking": "^2.0.0",
 				"string-width": "^2.0.0",
 				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^9.0.2"
+				"y18n": "^3.2.1 || ^4.0.0",
+				"yargs-parser": "^11.1.1"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"cliui": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 				}
 			}
 		},
 		"yargs-parser": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
 			"requires": {
-				"camelcase": "^4.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				}
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		}
 	}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,7 +11,7 @@
     "microsoft-speech-browser-sdk": "^0.0.12",
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
-    "react-scripts": "^2.0.5",
+    "react-scripts": "^3.0.1",
     "url-search-params-polyfill": "^5.0.0",
     "web-speech-cognitive-services": "2.1.1-master.0f7758b"
   },


### PR DESCRIPTION
## Changelog

- Bumped dependencies by `npm audit` in [PR #9](https://github.com/compulim/react-say/pull/9)
   - `@babel/core@7.4.5` and related packages
   - `jest@24.8.0`
   - `lerna@3.14.1`
   - `memoize-one@5.0.4`
   - `react-scripts@3.0.1`
   - `rimraf@2.6.3`
