### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,17 +49,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       - `cancel` and `speak` is removed because the newer `synthesize` function offer same functionality with simplified interface
    - 🔥 All React components now accepts `ponyfill` instead of `speechSynthesis` and `speechSynthesisUtterance`
       - Using browser speech would become as simple as `<Say ponyfill={ window }>`
-- Bumped dependencies in [PR #XXX](https://github.com/compulim/react-say/pull/XXX)
-   - `@babel/cli@^7.7.0`
-   - `@babel/core@^7.7.2`
-   - `@babel/plugin-proposal-object-rest-spread@^7.6.2`
-   - `@babel/plugin-transform-runtime@^7.6.2`
-   - `@babel/preset-env@^7.7.1`
-   - `@babel/preset-react@^7.7.0`
-   - `@babel/runtime@^7.7.2`
-   - `jest@^24.9.0`
-   - `memoize-one@^5.1.1`
-   - `memoize-one@5.1.1`
+- Bumped dependencies in [PR #18](https://github.com/compulim/react-say/pull/18)
+   - [`@babel/cli@7.7.0`](https://npmjs.com/package/@babel/cli)
+   - [`@babel/core@7.7.2`](https://npmjs.com/package/@babel/core)
+   - [`@babel/plugin-proposal-object-rest-spread@7.6.2`](https://npmjs.com/package/@babel/plugin-proposal-object-rest-spread)
+   - [`@babel/plugin-transform-runtime@7.6.2`](https://npmjs.com/package/@babel/plugin-transform-runtime)
+   - [`@babel/preset-env@7.7.1`](https://npmjs.com/package/@babel/preset-env)
+   - [`@babel/preset-react@7.7.0`](https://npmjs.com/package/@babel/preset-react)
+   - [`@babel/runtime@7.7.2`](https://npmjs.com/package/@babel/runtime)
+   - [`jest@24.9.0`](https://npmjs.com/package/jest)
+   - [`memoize-one@5.1.1`](https://npmjs.com/package/memoize-one)
 
 ## [1.2.0] - 2019-05-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking changes
 
+- Now requires React 16.8.6 or up
 - Updates to `<Say>` component
    - Renamed prop `speak` to `text`
    - Will no longer renders its children
@@ -48,6 +49,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       - `cancel` and `speak` is removed because the newer `synthesize` function offer same functionality with simplified interface
    - 🔥 All React components now accepts `ponyfill` instead of `speechSynthesis` and `speechSynthesisUtterance`
       - Using browser speech would become as simple as `<Say ponyfill={ window }>`
+- Bumped dependencies in [PR #XXX](https://github.com/compulim/react-say/pull/XXX)
+   - `@babel/cli@^7.7.0`
+   - `@babel/core@^7.7.2`
+   - `@babel/plugin-proposal-object-rest-spread@^7.6.2`
+   - `@babel/plugin-transform-runtime@^7.6.2`
+   - `@babel/preset-env@^7.7.1`
+   - `@babel/preset-react@^7.7.0`
+   - `@babel/runtime@^7.7.2`
+   - `jest@^24.9.0`
+   - `memoize-one@^5.1.1`
+   - `memoize-one@5.1.1`
 
 ## [1.2.0] - 2019-05-28
 ### Changed

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -5,436 +5,20 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/cli": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.4.4.tgz",
-			"integrity": "sha512-XGr5YjQSjgTa6OzQZY57FAJsdeVSAKR/u/KA5exWIz66IKtv/zXtHy+fIZcMry/EgYegwuHE7vzGnrFhjdIAsQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.7.0.tgz",
+			"integrity": "sha512-jECEqAq6Ngf3pOhLSg7od9WKyrIacyh1oNNYtRXNn+ummSHCTXBamGywOAtiae34Vk7zKuQNnLvo2BKTMCoV4A==",
 			"dev": true,
 			"requires": {
-				"chokidar": "^2.0.4",
+				"chokidar": "^2.1.8",
 				"commander": "^2.8.1",
 				"convert-source-map": "^1.1.0",
 				"fs-readdir-recursive": "^1.1.0",
 				"glob": "^7.0.0",
-				"lodash": "^4.17.11",
-				"mkdirp": "^0.5.1",
-				"output-file-sync": "^2.0.0",
+				"lodash": "^4.17.13",
+				"make-dir": "^2.1.0",
 				"slash": "^2.0.0",
 				"source-map": "^0.5.0"
-			},
-			"dependencies": {
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					},
-					"dependencies": {
-						"normalize-path": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"remove-trailing-separator": "^1.0.1"
-							}
-						}
-					}
-				},
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true,
-					"optional": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true,
-					"optional": true
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"chokidar": {
-					"version": "2.1.6",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-					"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-each": "^1.0.1",
-						"braces": "^2.3.2",
-						"fsevents": "^1.2.7",
-						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.3",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"normalize-path": "^3.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.2.1",
-						"upath": "^1.1.1"
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"optional": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"optional": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true,
-					"optional": true
-				},
-				"is-glob": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true,
-					"optional": true
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true,
-					"optional": true
-				},
-				"output-file-sync": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-2.0.1.tgz",
-					"integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"is-plain-obj": "^1.1.0",
-						"mkdirp": "^0.5.1"
-					}
-				},
-				"readdirp": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"micromatch": "^3.1.10",
-						"readable-stream": "^2.0.2"
-					}
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/code-frame": {
@@ -447,152 +31,129 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
-			"integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.2.tgz",
+			"integrity": "sha512-eeD7VEZKfhK1KUXGiyPFettgF3m513f8FoBSWiQ1xTvl1RAopLs42Wp9+Ze911I6H0N9lNqJMDgoZT7gHsipeQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.4.4",
-				"@babel/helpers": "^7.4.4",
-				"@babel/parser": "^7.4.5",
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.4.5",
-				"@babel/types": "^7.4.4",
-				"convert-source-map": "^1.1.0",
+				"@babel/code-frame": "^7.5.5",
+				"@babel/generator": "^7.7.2",
+				"@babel/helpers": "^7.7.0",
+				"@babel/parser": "^7.7.2",
+				"@babel/template": "^7.7.0",
+				"@babel/traverse": "^7.7.2",
+				"@babel/types": "^7.7.2",
+				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.13",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.0.0"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4",
+						"@babel/types": "^7.7.2",
 						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/template": "^7.1.0",
-						"@babel/types": "^7.0.0"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.4.4",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.4.5",
-						"@babel/types": "^7.4.4",
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
-						"lodash": "^4.17.11"
+						"lodash": "^4.17.13"
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+				"convert-source-map": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+					"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"safe-buffer": "~5.1.1"
 					}
 				},
 				"debug": {
@@ -604,300 +165,211 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"globals": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
-				"json5": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.11.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-					"integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-			"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+			"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.4",
+				"@babel/types": "^7.7.2",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.11",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
-			}
-		},
-		"@babel/helper-annotate-as-pure": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.0.0"
+				"lodash": "^4.17.13",
+				"source-map": "^0.5.0"
 			},
 			"dependencies": {
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
+				}
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.0.tgz",
+			"integrity": "sha512-k50CQxMlYTYo+GGyUGFwpxKVtxVJi9yh61sXZji3zYHccK9RYliZGSTOgci85T+r+0VFN2nWbGM04PIqwfrpMg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
 				}
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
-			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.0.tgz",
+			"integrity": "sha512-Cd8r8zs4RKDwMG/92lpZcnn5WPQ3LAMQbCw42oqUh4s7vsSN5ANUZjMel0OOnxDLq57hoDDbai+ryygYfCTOsw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-explode-assignable-expression": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
 				}
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
-			"integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.0.tgz",
+			"integrity": "sha512-LSln3cexwInTMYYoFeVLKnYPPMfWNJ8PubTBs3hkh7wCu9iBaqq1OOyW+xGmEdLxT1nhsl+9SJ+h2oUDYz0l2A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.3.0",
+				"@babel/types": "^7.7.0",
 				"esutils": "^2.0.0"
 			},
 			"dependencies": {
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
 				}
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
-			"integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.0.tgz",
+			"integrity": "sha512-Su0Mdq7uSSWGZayGMMQ+z6lnL00mMCnGAbO/R0ZO9odIdB/WNU/VfQKqMQU0fdIsxQYbRjDM4BixIa93SQIpvw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.4.4",
-				"@babel/traverse": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/helper-hoist-variables": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.0.0"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4",
+						"@babel/types": "^7.7.2",
 						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/template": "^7.1.0",
-						"@babel/types": "^7.0.0"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.4.4",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.4.5",
-						"@babel/types": "^7.4.4",
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
-						"lodash": "^4.17.11"
+						"lodash": "^4.17.13"
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -909,292 +381,188 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"globals": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
 		},
-		"@babel/helper-define-map": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
-			"integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.2.tgz",
+			"integrity": "sha512-pAil/ZixjTlrzNpjx+l/C/wJk002Wo7XbbZ8oujH/AoJ3Juv0iN/UTcPUHXKMFLqsfS0Hy6Aow8M31brUYBlQQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/types": "^7.4.4",
-				"lodash": "^4.17.11"
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.6.0"
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.0.tgz",
+			"integrity": "sha512-kPKWPb0dMpZi+ov1hJiwse9dWweZsz3V9rP4KdytnX1E7z3cTNmFGglwklzFPuqIcHLIY3bgKSs4vkwXXdflQA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/types": "^7.7.0",
+				"lodash": "^4.17.13"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
 				"@babel/helper-function-name": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/template": "^7.1.0",
-						"@babel/types": "^7.0.0"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.0.0"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
 				}
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
-			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.0.tgz",
+			"integrity": "sha512-CDs26w2shdD1urNUAji2RJXyBFCaR+iBEGnFz3l7maizMkQe3saVw9WtjG1tz8CwbjvlFnaSLVhgnu1SWaherg==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.0.0"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4",
+						"@babel/types": "^7.7.2",
 						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/template": "^7.1.0",
-						"@babel/types": "^7.0.0"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.4.4",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.4.5",
-						"@babel/types": "^7.4.4",
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
-						"lodash": "^4.17.11"
+						"lodash": "^4.17.13"
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -1206,50 +574,45 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"globals": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+			"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.0.0",
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-get-function-arity": "^7.7.0",
+				"@babel/template": "^7.7.0",
+				"@babel/types": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-get-function-arity": {
@@ -1262,58 +625,46 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
-			"integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.0.tgz",
+			"integrity": "sha512-LUe/92NqsDAkJjjCEWkNe+/PcpnisvnqdlRe19FahVapa4jndeuJ+FBiTX1rcAKWKcJGE+C3Q3tuEuxkSmCEiQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.4"
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
 				}
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-			"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.0.tgz",
+			"integrity": "sha512-QaCZLO2RtBcmvO/ekOLp8p7R5X2JriKRizeDpm5ChATAFWrrYDcDxPuCIBXKyBjY+i1vYSdcUTMIb8psfxHDPA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
 				}
 			}
 		},
@@ -1346,138 +697,86 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
-			"integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.0.tgz",
+			"integrity": "sha512-rXEefBuheUYQyX4WjV19tuknrJFwyKw0HgzRwbkyTbB+Dshlq7eqkWbyjzToLrMZk/5wKVKdWFluiAsVkHXvuQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/helper-simple-access": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/template": "^7.4.4",
-				"@babel/types": "^7.4.4",
-				"lodash": "^4.17.11"
+				"@babel/helper-module-imports": "^7.7.0",
+				"@babel/helper-simple-access": "^7.7.0",
+				"@babel/helper-split-export-declaration": "^7.7.0",
+				"@babel/template": "^7.7.0",
+				"@babel/types": "^7.7.0",
+				"lodash": "^4.17.13"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+				"@babel/helper-module-imports": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
+					"integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
 					"dev": true,
 					"requires": {
-						"@babel/highlight": "^7.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
 				}
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.0.tgz",
+			"integrity": "sha512-48TeqmbazjNU/65niiiJIJRc5JozB8acui1OS7bSd6PgxfuovWsvjfWSzlgx+gPFdVveNzUdpdIg5l56Pl5jqg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
 				}
 			}
 		},
@@ -1488,152 +787,122 @@
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
-			"integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+			"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
-			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.0.tgz",
+			"integrity": "sha512-pHx7RN8X0UNHPB/fnuDnRXVZ316ZigkO8y8D835JlZ2SSdFKb6yH9MIYRU4fy/KPe5sPHDFOPvf8QLdbAGGiyw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-wrap-function": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-annotate-as-pure": "^7.7.0",
+				"@babel/helper-wrap-function": "^7.7.0",
+				"@babel/template": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
 				"@babel/generator": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4",
+						"@babel/types": "^7.7.2",
 						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/template": "^7.1.0",
-						"@babel/types": "^7.0.0"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.4.4",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.4.5",
-						"@babel/types": "^7.4.4",
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
-						"lodash": "^4.17.11"
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/code-frame": {
+							"version": "7.5.5",
+							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+							"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+							"dev": true,
+							"requires": {
+								"@babel/highlight": "^7.0.0"
+							}
+						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -1645,178 +914,119 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"globals": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
-			"integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.0.tgz",
+			"integrity": "sha512-5ALYEul5V8xNdxEeWvRsBzLMxQksT7MaStpxjJf9KsnLxpAKBtfw5NeMKZJSYDa0lKdOcy0g+JT/f5mPSulUgg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.0.0",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/traverse": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/helper-member-expression-to-functions": "^7.7.0",
+				"@babel/helper-optimise-call-expression": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.0.0"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4",
+						"@babel/types": "^7.7.2",
 						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/template": "^7.1.0",
-						"@babel/types": "^7.0.0"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.4.4",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.4.5",
-						"@babel/types": "^7.4.4",
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
-						"lodash": "^4.17.11"
+						"lodash": "^4.17.13"
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -1828,282 +1038,183 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"globals": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
-			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.0.tgz",
+			"integrity": "sha512-AJ7IZD7Eem3zZRuj5JtzFAptBw7pMlS3y8Qv09vaBWoFsle0d1kAn5Wq6Q9MyBXITPOKnxwkZKoAm4bopmv26g==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/template": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
-					}
-				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
 				}
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+			"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.4"
+				"@babel/types": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
-			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.0.tgz",
+			"integrity": "sha512-sd4QjeMgQqzshSjecZjOp8uKfUtnpmCyQhKQrVJBBgeHAB/0FPi33h3AbVlVp07qQtMD4QgYSzaMI7VwncNK/w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.2.0"
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/template": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
 				"@babel/generator": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4",
+						"@babel/types": "^7.7.2",
 						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/template": "^7.1.0",
-						"@babel/types": "^7.0.0"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.4.4",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.4.5",
-						"@babel/types": "^7.4.4",
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
-						"lodash": "^4.17.11"
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/code-frame": {
+							"version": "7.5.5",
+							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+							"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+							"dev": true,
+							"requires": {
+								"@babel/highlight": "^7.0.0"
+							}
+						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -2115,177 +1226,120 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"globals": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
-			"integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
+			"integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/template": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
 				"@babel/generator": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4",
+						"@babel/types": "^7.7.2",
 						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/template": "^7.1.0",
-						"@babel/types": "^7.0.0"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.4.4",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.4.5",
-						"@babel/types": "^7.4.4",
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
-						"lodash": "^4.17.11"
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/code-frame": {
+							"version": "7.5.5",
+							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+							"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+							"dev": true,
+							"requires": {
+								"@babel/highlight": "^7.0.0"
+							}
+						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -2297,37 +1351,10 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"globals": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
@@ -2344,20 +1371,30 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-			"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+			"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
-			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.0.tgz",
+			"integrity": "sha512-ot/EZVvf3mXtZq0Pd0+tSOfGWMizqmOohXmNZg6LNFjHOV+wOPv7BvVYh8oPR8LhpIP3ye8nNooKL50YRWxpYA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.1.0",
+				"@babel/helper-remap-async-to-generator": "^7.7.0",
 				"@babel/plugin-syntax-async-generators": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-dynamic-import": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.0.tgz",
+			"integrity": "sha512-7poL3Xi+QFPC7sGAzEIbXUyYzGJwbc2+gSD0AkiC5k52kH2cqHdqxm5hNFfLW3cRSTcx9bN0Fl7/6zWcLLnKAQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
@@ -2371,9 +1408,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
-			"integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+			"integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -2391,57 +1428,28 @@
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
-			"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.0.tgz",
+			"integrity": "sha512-mk34H+hp7kRBWJOOAR0ZMGCydgKMD4iN9TpDRp3IIcbunltxEY89XSimc6WbtSLCDrwcdy/EEw7h5CFCzxTchw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
-				},
-				"regexpu-core": {
-					"version": "4.5.4",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-					"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
-					"dev": true,
-					"requires": {
-						"regenerate": "^1.4.0",
-						"regenerate-unicode-properties": "^8.0.2",
-						"regjsgen": "^0.5.0",
-						"regjsparser": "^0.6.0",
-						"unicode-match-property-ecmascript": "^1.0.4",
-						"unicode-match-property-value-ecmascript": "^1.1.0"
-					}
-				},
-				"regjsgen": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-					"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
-					"dev": true
-				},
-				"regjsparser": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-					"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
-					"dev": true,
-					"requires": {
-						"jsesc": "~0.5.0"
-					}
-				}
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
 			"integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+			"integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -2483,6 +1491,15 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.0.tgz",
+			"integrity": "sha512-hi8FUNiFIY1fnUI2n1ViB1DR0R4QeK4iHcTlW6aJkrPoTdb8Rf1EMQ6GT3f67DDkYyWgew9DFoOZ6gOoEsdzTA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-transform-arrow-functions": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
@@ -2493,14 +1510,36 @@
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
-			"integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.0.tgz",
+			"integrity": "sha512-vLI2EFLVvRBL3d8roAMqtVY0Bm9C1QzLkdS57hiKrjUBSqsQYrBsMCeOg/0KK7B0eK9V71J5mWcha9yyoI2tZw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-module-imports": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.1.0"
+				"@babel/helper-remap-async-to-generator": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
+					"integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
@@ -2513,148 +1552,87 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
-			"integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
+			"integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
-			"integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.0.tgz",
+			"integrity": "sha512-/b3cKIZwGeUesZheU9jNYcwrEA7f/Bo4IdPmvp7oHgvks2majB5BoT5byAql44fiNQYOPzhk2w8DbgfuafkMoA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-define-map": "^7.4.4",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-annotate-as-pure": "^7.7.0",
+				"@babel/helper-define-map": "^7.7.0",
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/helper-optimise-call-expression": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.4.4",
-				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/helper-replace-supers": "^7.7.0",
+				"@babel/helper-split-export-declaration": "^7.7.0",
 				"globals": "^11.1.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
 				"@babel/helper-function-name": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/template": "^7.1.0",
-						"@babel/types": "^7.0.0"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"globals": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
 				}
 			}
 		},
@@ -2668,66 +1646,28 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
-			"integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+			"integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
-			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.0.tgz",
+			"integrity": "sha512-3QQlF7hSBnSuM1hQ0pS3pmAbWLax/uGNCbPBND9y+oJ4Y776jsyujG2k0Sn2Aj2a0QwVOiOFL5QVPA7spjvzSA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
-				},
-				"regexpu-core": {
-					"version": "4.5.4",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-					"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
-					"dev": true,
-					"requires": {
-						"regenerate": "^1.4.0",
-						"regenerate-unicode-properties": "^8.0.2",
-						"regjsgen": "^0.5.0",
-						"regjsparser": "^0.6.0",
-						"unicode-match-property-ecmascript": "^1.0.4",
-						"unicode-match-property-value-ecmascript": "^1.1.0"
-					}
-				},
-				"regjsgen": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-					"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
-					"dev": true
-				},
-				"regjsparser": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-					"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
-					"dev": true,
-					"requires": {
-						"jsesc": "~0.5.0"
-					}
-				}
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
-			"integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+			"integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -2753,117 +1693,62 @@
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
-			"integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.0.tgz",
+			"integrity": "sha512-P5HKu0d9+CzZxP5jcrWdpe7ZlFDe24bmqP6a6X8BHEBl/eizAsY8K6LX8LASZL0Jxdjm5eEfzp+FIrxCm/p8bA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-function-name": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
 				"@babel/helper-function-name": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/template": "^7.1.0",
-						"@babel/types": "^7.0.0"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.0.0"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
 				}
 			}
 		},
@@ -2886,53 +1771,56 @@
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
-			"integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+			"integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
-			"integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.0.tgz",
+			"integrity": "sha512-KEMyWNNWnjOom8vR/1+d+Ocz/mILZG/eyHHO06OuBQ2aNhxT62fr4y6fGOplRx+CxCSp3IFwesL8WdINfY/3kg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.4.4",
+				"@babel/helper-module-transforms": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-simple-access": "^7.1.0"
+				"@babel/helper-simple-access": "^7.7.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
-			"integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.0.tgz",
+			"integrity": "sha512-ZAuFgYjJzDNv77AjXRqzQGlQl4HdUM6j296ee4fwKVZfhDR9LAGxfvXjBkb06gNETPnN0sLqRm9Gxg4wZH6dXg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.4.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-hoist-variables": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
-			"integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.0.tgz",
+			"integrity": "sha512-u7eBA03zmUswQ9LQ7Qw0/ieC1pcAkbp5OQatbWUzY1PaBccvuJXUkYzoN1g7cqp7dbTu6Dp9bXyalBvD04AANA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-module-transforms": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
-			"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.0.tgz",
+			"integrity": "sha512-+SicSJoKouPctL+j1pqktRVCgy+xAch1hWWTMy13j0IflnyNjaoskj+DwRQFimHbLqO3sq2oN2CXMvXq3Bgapg==",
 			"dev": true,
 			"requires": {
-				"regexp-tree": "^0.1.6"
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -2945,13 +1833,13 @@
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
-			"integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+			"integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.1.0"
+				"@babel/helper-replace-supers": "^7.5.5"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
@@ -2963,34 +1851,6 @@
 				"@babel/helper-call-delegate": "^7.4.4",
 				"@babel/helper-get-function-arity": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
-			},
-			"dependencies": {
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.0.0"
-					}
-				},
-				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-transform-property-literals": {
@@ -3012,12 +1872,12 @@
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
-			"integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.0.tgz",
+			"integrity": "sha512-mXhBtyVB1Ujfy+0L6934jeJcSXj/VCg6whZzEcgiiZHNS0PGC7vUCsZDQCxxztkpIdF+dY1fUMcjAgEOC3ZOMQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx": "^7.3.0",
+				"@babel/helper-builder-react-jsx": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-jsx": "^7.2.0"
 			}
@@ -3033,9 +1893,9 @@
 			}
 		},
 		"@babel/plugin-transform-react-jsx-source": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
-			"integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
+			"integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -3043,23 +1903,12 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
-			"integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.0.tgz",
+			"integrity": "sha512-AXmvnC+0wuj/cFkkS/HFHIojxH3ffSXE+ttulrqWjZZRaUOonfJc60e1wSNT4rV8tIunvu/R3wCp71/tLAa9xg==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.14.0"
-			},
-			"dependencies": {
-				"regenerator-transform": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
-					"integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
-					"dev": true,
-					"requires": {
-						"private": "^0.1.6"
-					}
-				}
 			}
 		},
 		"@babel/plugin-transform-reserved-words": {
@@ -3072,26 +1921,15 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz",
-			"integrity": "sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz",
+			"integrity": "sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"resolve": "^1.8.1",
 				"semver": "^5.5.1"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.11.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-					"integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
-				}
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
@@ -3104,9 +1942,9 @@
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+			"integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -3142,102 +1980,67 @@
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
-			"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.0.tgz",
+			"integrity": "sha512-RrThb0gdrNwFAqEAAx9OWgtx6ICK69x7i9tCnMdVrxQwSDp/Abu9DXFU5Hh16VP33Rmxh04+NGW28NsIkFvFKA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
-				},
-				"regexpu-core": {
-					"version": "4.5.4",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-					"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
-					"dev": true,
-					"requires": {
-						"regenerate": "^1.4.0",
-						"regenerate-unicode-properties": "^8.0.2",
-						"regjsgen": "^0.5.0",
-						"regjsparser": "^0.6.0",
-						"unicode-match-property-ecmascript": "^1.0.4",
-						"unicode-match-property-value-ecmascript": "^1.1.0"
-					}
-				},
-				"regjsgen": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-					"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
-					"dev": true
-				},
-				"regjsparser": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-					"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
-					"dev": true,
-					"requires": {
-						"jsesc": "~0.5.0"
-					}
-				}
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.5.tgz",
-			"integrity": "sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.1.tgz",
+			"integrity": "sha512-/93SWhi3PxcVTDpSqC+Dp4YxUu3qZ4m7I76k0w73wYfn7bGVuRIO4QUz95aJksbS+AD1/mT1Ie7rbkT0wSplaA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-module-imports": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+				"@babel/plugin-proposal-async-generator-functions": "^7.7.0",
+				"@babel/plugin-proposal-dynamic-import": "^7.7.0",
 				"@babel/plugin-proposal-json-strings": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+				"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.7.0",
 				"@babel/plugin-syntax-async-generators": "^7.2.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
 				"@babel/plugin-syntax-json-strings": "^7.2.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+				"@babel/plugin-syntax-top-level-await": "^7.7.0",
 				"@babel/plugin-transform-arrow-functions": "^7.2.0",
-				"@babel/plugin-transform-async-to-generator": "^7.4.4",
+				"@babel/plugin-transform-async-to-generator": "^7.7.0",
 				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.4.4",
-				"@babel/plugin-transform-classes": "^7.4.4",
+				"@babel/plugin-transform-block-scoping": "^7.6.3",
+				"@babel/plugin-transform-classes": "^7.7.0",
 				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.4.4",
-				"@babel/plugin-transform-dotall-regex": "^7.4.4",
-				"@babel/plugin-transform-duplicate-keys": "^7.2.0",
+				"@babel/plugin-transform-destructuring": "^7.6.0",
+				"@babel/plugin-transform-dotall-regex": "^7.7.0",
+				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
 				"@babel/plugin-transform-for-of": "^7.4.4",
-				"@babel/plugin-transform-function-name": "^7.4.4",
+				"@babel/plugin-transform-function-name": "^7.7.0",
 				"@babel/plugin-transform-literals": "^7.2.0",
 				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
-				"@babel/plugin-transform-modules-amd": "^7.2.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.4.4",
-				"@babel/plugin-transform-modules-systemjs": "^7.4.4",
-				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+				"@babel/plugin-transform-modules-amd": "^7.5.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.7.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.7.0",
+				"@babel/plugin-transform-modules-umd": "^7.7.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.0",
 				"@babel/plugin-transform-new-target": "^7.4.4",
-				"@babel/plugin-transform-object-super": "^7.2.0",
+				"@babel/plugin-transform-object-super": "^7.5.5",
 				"@babel/plugin-transform-parameters": "^7.4.4",
 				"@babel/plugin-transform-property-literals": "^7.2.0",
-				"@babel/plugin-transform-regenerator": "^7.4.5",
+				"@babel/plugin-transform-regenerator": "^7.7.0",
 				"@babel/plugin-transform-reserved-words": "^7.2.0",
 				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-				"@babel/plugin-transform-spread": "^7.2.0",
+				"@babel/plugin-transform-spread": "^7.6.2",
 				"@babel/plugin-transform-sticky-regex": "^7.2.0",
 				"@babel/plugin-transform-template-literals": "^7.4.4",
 				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.4.4",
-				"@babel/types": "^7.4.4",
+				"@babel/plugin-transform-unicode-regex": "^7.7.0",
+				"@babel/types": "^7.7.1",
 				"browserslist": "^4.6.0",
 				"core-js-compat": "^3.1.1",
 				"invariant": "^2.2.2",
@@ -3245,97 +2048,110 @@
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
+					"integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
 				"@babel/types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"browserslist": {
-					"version": "4.6.1",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
-					"integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30000971",
-						"electron-to-chromium": "^1.3.137",
-						"node-releases": "^1.1.21"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30000971",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
-					"integrity": "sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==",
-					"dev": true
-				},
-				"electron-to-chromium": {
-					"version": "1.3.137",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
-					"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==",
-					"dev": true
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
 				}
 			}
 		},
 		"@babel/preset-react": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
-			"integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.7.0.tgz",
+			"integrity": "sha512-IXXgSUYBPHUGhUkH+89TR6faMcBtuMW0h5OHbMuVbL3/5wK2g6a2M2BBpkLa+Kw0sAHiZ9dNVgqJMDP/O4GRBA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-transform-react-display-name": "^7.0.0",
-				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.7.0",
 				"@babel/plugin-transform-react-jsx-self": "^7.0.0",
 				"@babel/plugin-transform-react-jsx-source": "^7.0.0"
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-			"integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
+			"integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+			"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/parser": "^7.7.0",
+				"@babel/types": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-			"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+			"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.4.4",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.4.5",
-				"@babel/types": "^7.4.4",
+				"@babel/code-frame": "^7.5.5",
+				"@babel/generator": "^7.7.2",
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/helper-split-export-declaration": "^7.7.0",
+				"@babel/parser": "^7.7.2",
+				"@babel/types": "^7.7.2",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.13"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -3346,9 +2162,9 @@
 					}
 				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
@@ -3383,92 +2199,93 @@
 			}
 		},
 		"@jest/console": {
-			"version": "24.7.1",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
-			"integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+			"integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
 			"dev": true,
 			"requires": {
-				"@jest/source-map": "^24.3.0",
+				"@jest/source-map": "^24.9.0",
 				"chalk": "^2.0.1",
 				"slash": "^2.0.0"
 			}
 		},
 		"@jest/core": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
-			"integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
+			"integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
 			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
-				"@jest/reporters": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/reporters": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.15",
-				"jest-changed-files": "^24.8.0",
-				"jest-config": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-message-util": "^24.8.0",
+				"jest-changed-files": "^24.9.0",
+				"jest-config": "^24.9.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-message-util": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-resolve-dependencies": "^24.8.0",
-				"jest-runner": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
-				"jest-watcher": "^24.8.0",
+				"jest-resolve": "^24.9.0",
+				"jest-resolve-dependencies": "^24.9.0",
+				"jest-runner": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-snapshot": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-validate": "^24.9.0",
+				"jest-watcher": "^24.9.0",
 				"micromatch": "^3.1.10",
 				"p-each-series": "^1.0.0",
-				"pirates": "^4.0.1",
 				"realpath-native": "^1.1.0",
 				"rimraf": "^2.5.4",
+				"slash": "^2.0.0",
 				"strip-ansi": "^5.0.0"
 			},
 			"dependencies": {
 				"graceful-fs": {
-					"version": "4.1.15",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 					"dev": true
 				}
 			}
 		},
 		"@jest/environment": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
-			"integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
+			"integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0"
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"jest-mock": "^24.9.0"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
-			"integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+			"integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-mock": "^24.8.0"
+				"@jest/types": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-mock": "^24.9.0"
 			}
 		},
 		"@jest/reporters": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
-			"integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
+			"integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"glob": "^7.1.2",
@@ -3476,13 +2293,13 @@
 				"istanbul-lib-instrument": "^3.0.1",
 				"istanbul-lib-report": "^2.0.4",
 				"istanbul-lib-source-maps": "^3.0.1",
-				"istanbul-reports": "^2.1.1",
-				"jest-haste-map": "^24.8.0",
-				"jest-resolve": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-util": "^24.8.0",
+				"istanbul-reports": "^2.2.6",
+				"jest-haste-map": "^24.9.0",
+				"jest-resolve": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"jest-worker": "^24.6.0",
-				"node-notifier": "^5.2.1",
+				"node-notifier": "^5.4.2",
 				"slash": "^2.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^2.0.0"
@@ -3497,9 +2314,9 @@
 			}
 		},
 		"@jest/source-map": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
-			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+			"integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0",
@@ -3508,9 +2325,9 @@
 			},
 			"dependencies": {
 				"graceful-fs": {
-					"version": "4.1.15",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 					"dev": true
 				},
 				"source-map": {
@@ -3522,45 +2339,46 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
-			"integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+			"integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/types": "^24.8.0",
+				"@jest/console": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"@types/istanbul-lib-coverage": "^2.0.0"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
-			"integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+			"integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-runner": "^24.8.0",
-				"jest-runtime": "^24.8.0"
+				"@jest/test-result": "^24.9.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-runner": "^24.9.0",
+				"jest-runtime": "^24.9.0"
 			}
 		},
 		"@jest/transform": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
-			"integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
+			"integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"babel-plugin-istanbul": "^5.1.0",
 				"chalk": "^2.0.1",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.1.15",
-				"jest-haste-map": "^24.8.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-util": "^24.8.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-regex-util": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"micromatch": "^3.1.10",
+				"pirates": "^4.0.1",
 				"realpath-native": "^1.1.0",
 				"slash": "^2.0.0",
 				"source-map": "^0.6.1",
@@ -3568,9 +2386,9 @@
 			},
 			"dependencies": {
 				"graceful-fs": {
-					"version": "4.1.15",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 					"dev": true
 				},
 				"source-map": {
@@ -3582,20 +2400,20 @@
 			}
 		},
 		"@jest/types": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
-			"integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^1.1.1",
-				"@types/yargs": "^12.0.9"
+				"@types/yargs": "^13.0.0"
 			}
 		},
 		"@types/babel__core": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
-			"integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
+			"integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -3606,9 +2424,9 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
-			"integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.0.tgz",
+			"integrity": "sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
@@ -3625,9 +2443,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
-			"integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
+			"integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
@@ -3665,15 +2483,24 @@
 			"dev": true
 		},
 		"@types/yargs": {
-			"version": "12.0.12",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
-			"integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
+			"version": "13.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
+			"integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
+			"dev": true,
+			"requires": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"@types/yargs-parser": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
 			"dev": true
 		},
 		"abab": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+			"integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
 			"dev": true
 		},
 		"acorn": {
@@ -3683,9 +2510,9 @@
 			"dev": true
 		},
 		"acorn-globals": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
-			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
@@ -3693,23 +2520,23 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
 					"dev": true
 				}
 			}
 		},
 		"acorn-walk": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
 		},
 		"ajv": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
@@ -3737,6 +2564,16 @@
 			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
+			}
+		},
+		"anymatch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"dev": true,
+			"requires": {
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
 			}
 		},
 		"arr-diff": {
@@ -3769,11 +2606,6 @@
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
 		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -3802,16 +2634,16 @@
 			"dev": true
 		},
 		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true,
 			"optional": true
 		},
 		"async-limiter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
 			"dev": true
 		},
 		"asynckit": {
@@ -3839,48 +2671,58 @@
 			"dev": true
 		},
 		"babel-jest": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
-			"integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
+			"integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"@types/babel__core": "^7.1.0",
 				"babel-plugin-istanbul": "^5.1.0",
-				"babel-preset-jest": "^24.6.0",
+				"babel-preset-jest": "^24.9.0",
 				"chalk": "^2.4.2",
 				"slash": "^2.0.0"
 			}
 		},
-		"babel-plugin-istanbul": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
-			"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
+		"babel-plugin-dynamic-import-node": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
 			"dev": true,
 			"requires": {
+				"object.assign": "^4.1.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+			"integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
 				"find-up": "^3.0.0",
 				"istanbul-lib-instrument": "^3.3.0",
 				"test-exclude": "^5.2.3"
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "24.6.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
-			"integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+			"integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
 			"dev": true,
 			"requires": {
 				"@types/babel__traverse": "^7.0.6"
 			}
 		},
 		"babel-preset-jest": {
-			"version": "24.6.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
-			"integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+			"integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
 			"dev": true,
 			"requires": {
 				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-				"babel-plugin-jest-hoist": "^24.6.0"
+				"babel-plugin-jest-hoist": "^24.9.0"
 			}
 		},
 		"balanced-match": {
@@ -3960,16 +2802,11 @@
 			}
 		},
 		"binary-extensions": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true,
 			"optional": true
-		},
-		"bowser": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-			"integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -4033,10 +2870,21 @@
 				}
 			}
 		},
+		"browserslist": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.3.tgz",
+			"integrity": "sha512-jWvmhqYpx+9EZm/FxcZSbUZyDEvDTLDi3nSAKbzEkyWvtI0mNSmUosey+5awDW1RUlrgXbQb5A6qY1xQH9U6MQ==",
+			"dev": true,
+			"requires": {
+				"caniuse-lite": "^1.0.30001010",
+				"electron-to-chromium": "^1.3.306",
+				"node-releases": "^1.1.40"
+			}
+		},
 		"bser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
 			"dev": true,
 			"requires": {
 				"node-int64": "^0.4.0"
@@ -4077,6 +2925,12 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true
 		},
+		"caniuse-lite": {
+			"version": "1.0.30001010",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001010.tgz",
+			"integrity": "sha512-RA5GH9YjFNea4ZQszdWgh2SC+dpLiRAg4VDQS2b5JRI45OxmbGrYocYHTa9x0bKMQUE7uvHkNPNffUr+pCxSGw==",
+			"dev": true
+		},
 		"capture-exit": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -4101,6 +2955,36 @@
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
+			}
+		},
+		"chokidar": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"anymatch": "^2.0.0",
+				"async-each": "^1.0.1",
+				"braces": "^2.3.2",
+				"fsevents": "^1.2.7",
+				"glob-parent": "^3.1.0",
+				"inherits": "^2.0.3",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"normalize-path": "^3.0.0",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.2.1",
+				"upath": "^1.1.1"
+			},
+			"dependencies": {
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true,
+					"optional": true
+				}
 			}
 		},
 		"ci-info": {
@@ -4138,43 +3022,20 @@
 			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"cliui": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
 			"dev": true,
 			"requires": {
-				"string-width": "^2.1.1",
-				"strip-ansi": "^4.0.0",
-				"wrap-ansi": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
+				"string-width": "^3.1.0",
+				"strip-ansi": "^5.2.0",
+				"wrap-ansi": "^5.1.0"
 			}
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
-		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 			"dev": true
 		},
 		"collection-visit": {
@@ -4212,9 +3073,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.17.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
 		"component-emitter": {
@@ -4242,52 +3103,22 @@
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.3.tgz",
-			"integrity": "sha512-EP018pVhgwsKHz3YoN1hTq49aRe+h017Kjz0NQz3nXV0cCRMvH3fLQl+vEPGr4r4J5sk4sU3tUC7U1aqTCeJeA==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.1.tgz",
+			"integrity": "sha512-YdeJI26gLc0CQJ9asLE5obEgBz2I0+CIgnoTbS2T0d5IPQw/OCgCIFR527RmpduxjrB3gSEHoGOCTq9sigOyfw==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.6.0",
-				"core-js-pure": "3.1.3",
-				"semver": "^6.1.0"
+				"browserslist": "^4.7.2",
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"browserslist": {
-					"version": "4.6.1",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
-					"integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30000971",
-						"electron-to-chromium": "^1.3.137",
-						"node-releases": "^1.1.21"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30000971",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
-					"integrity": "sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==",
-					"dev": true
-				},
-				"electron-to-chromium": {
-					"version": "1.3.137",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
-					"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==",
-					"dev": true
-				},
 				"semver": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
-					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
-		},
-		"core-js-pure": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.3.tgz",
-			"integrity": "sha512-k3JWTrcQBKqjkjI0bkfXS0lbpWPxYuHWfMMjC1VDmzU4Q58IwSbuXSo99YO/hUHlw/EB4AlfA2PVxOGkrIq6dA==",
-			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -4308,25 +3139,16 @@
 				"which": "^1.2.9"
 			}
 		},
-		"css-in-js-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-			"integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-			"requires": {
-				"hyphenate-style-name": "^1.0.2",
-				"isobject": "^3.0.1"
-			}
-		},
 		"cssom": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
-			"integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
 			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
@@ -4353,9 +3175,9 @@
 			},
 			"dependencies": {
 				"whatwg-url": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
 					"dev": true,
 					"requires": {
 						"lodash.sortby": "^4.7.0",
@@ -4461,9 +3283,9 @@
 			"dev": true
 		},
 		"diff-sequences": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
-			"integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+			"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
 			"dev": true
 		},
 		"domexception": {
@@ -4485,18 +3307,22 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"requires": {
-				"iconv-lite": "~0.4.13"
-			}
+		"electron-to-chromium": {
+			"version": "1.3.306",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.306.tgz",
+			"integrity": "sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A==",
+			"dev": true
+		},
+		"emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
@@ -4512,23 +3338,27 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
+				"has-symbols": "^1.0.0",
 				"is-callable": "^1.1.4",
 				"is-regex": "^1.0.4",
-				"object-keys": "^1.0.12"
+				"object-inspect": "^1.6.0",
+				"object-keys": "^1.1.1",
+				"string.prototype.trimleft": "^2.1.0",
+				"string.prototype.trimright": "^2.1.0"
 			}
 		},
 		"es-to-primitive": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
 			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
@@ -4543,9 +3373,9 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+			"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
 			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
@@ -4571,9 +3401,9 @@
 			"dev": true
 		},
 		"estraverse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
 		"esutils": {
@@ -4588,9 +3418,9 @@
 			"integrity": "sha512-z/WIlyou7oTvXBjm5YYjfklr2d8gUWtx8b5GAcrIs1n1D35f7NIK0CrcYSXbY3VYikG9bUan+wScPyGXL/NH4A=="
 		},
 		"exec-sh": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
-			"integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
+			"integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
 			"dev": true
 		},
 		"execa": {
@@ -4650,17 +3480,17 @@
 			}
 		},
 		"expect": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
-			"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+			"integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"ansi-styles": "^3.2.0",
-				"jest-get-type": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-regex-util": "^24.3.0"
+				"jest-get-type": "^24.9.0",
+				"jest-matcher-utils": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-regex-util": "^24.9.0"
 			}
 		},
 		"extend": {
@@ -4792,27 +3622,6 @@
 			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.17",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-				}
 			}
 		},
 		"fill-range": {
@@ -5446,9 +4255,9 @@
 			"dev": true
 		},
 		"get-caller-file": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
 		"get-stream": {
@@ -5475,18 +4284,6 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"glamor": {
-			"version": "2.20.40",
-			"resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
-			"integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
-			"requires": {
-				"fbjs": "^0.8.12",
-				"inline-style-prefixer": "^3.0.6",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.5.10",
-				"through": "^2.3.8"
-			}
-		},
 		"glob": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -5499,6 +4296,29 @@
 				"minimatch": "^3.0.4",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
 			}
 		},
 		"globals": {
@@ -5520,9 +4340,9 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.4.5",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-			"integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+			"integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -5635,9 +4455,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
 			"dev": true
 		},
 		"html-encoding-sniffer": {
@@ -5660,15 +4480,11 @@
 				"sshpk": "^1.7.0"
 			}
 		},
-		"hyphenate-style-name": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-			"integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
-		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -5705,15 +4521,6 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true
 		},
-		"inline-style-prefixer": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
-			"integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
-			"requires": {
-				"bowser": "^1.7.3",
-				"css-in-js-utils": "^2.0.0"
-			}
-		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -5722,12 +4529,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"invert-kv": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-			"dev": true
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -5815,6 +4616,13 @@
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
 			"dev": true
 		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true,
+			"optional": true
+		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -5827,6 +4635,16 @@
 			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 			"dev": true
 		},
+		"is-glob": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
+		},
 		"is-number": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -5835,12 +4653,6 @@
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
-		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -5863,7 +4675,8 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.2",
@@ -5907,16 +4720,8 @@
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
-			}
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -5946,9 +4751,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
-					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -5998,19 +4803,10 @@
 					}
 				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -6030,233 +4826,224 @@
 			}
 		},
 		"jest": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",
-			"integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+			"integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
 			"dev": true,
 			"requires": {
 				"import-local": "^2.0.0",
-				"jest-cli": "^24.8.0"
+				"jest-cli": "^24.9.0"
 			},
 			"dependencies": {
 				"jest-cli": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz",
-					"integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+					"integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^24.8.0",
-						"@jest/test-result": "^24.8.0",
-						"@jest/types": "^24.8.0",
+						"@jest/core": "^24.9.0",
+						"@jest/test-result": "^24.9.0",
+						"@jest/types": "^24.9.0",
 						"chalk": "^2.0.1",
 						"exit": "^0.1.2",
 						"import-local": "^2.0.0",
 						"is-ci": "^2.0.0",
-						"jest-config": "^24.8.0",
-						"jest-util": "^24.8.0",
-						"jest-validate": "^24.8.0",
+						"jest-config": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"jest-validate": "^24.9.0",
 						"prompts": "^2.0.1",
 						"realpath-native": "^1.1.0",
-						"yargs": "^12.0.2"
+						"yargs": "^13.3.0"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
-			"integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+			"integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"execa": "^1.0.0",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
-			"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
+			"integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"babel-jest": "^24.8.0",
+				"@jest/test-sequencer": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"babel-jest": "^24.9.0",
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^24.8.0",
-				"jest-environment-node": "^24.8.0",
-				"jest-get-type": "^24.8.0",
-				"jest-jasmine2": "^24.8.0",
+				"jest-environment-jsdom": "^24.9.0",
+				"jest-environment-node": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"jest-jasmine2": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
+				"jest-resolve": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-validate": "^24.9.0",
 				"micromatch": "^3.1.10",
-				"pretty-format": "^24.8.0",
+				"pretty-format": "^24.9.0",
 				"realpath-native": "^1.1.0"
 			}
 		},
 		"jest-diff": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
-			"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+			"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"diff-sequences": "^24.3.0",
-				"jest-get-type": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"diff-sequences": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-docblock": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
-			"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
+			"integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
 			"dev": true,
 			"requires": {
 				"detect-newline": "^2.1.0"
 			}
 		},
 		"jest-each": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
-			"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
+			"integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
-				"jest-get-type": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"jest-get-type": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
-			"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+			"integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0",
-				"jest-util": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"jest-mock": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"jsdom": "^11.5.1"
 			}
 		},
 		"jest-environment-node": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
-			"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+			"integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0",
-				"jest-util": "^24.8.0"
+				"@jest/environment": "^24.9.0",
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"jest-mock": "^24.9.0",
+				"jest-util": "^24.9.0"
 			}
 		},
 		"jest-get-type": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
-			"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+			"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
-			"integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+			"integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"anymatch": "^2.0.0",
 				"fb-watchman": "^2.0.0",
 				"fsevents": "^1.2.7",
 				"graceful-fs": "^4.1.15",
 				"invariant": "^2.2.4",
-				"jest-serializer": "^24.4.0",
-				"jest-util": "^24.8.0",
-				"jest-worker": "^24.6.0",
+				"jest-serializer": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-worker": "^24.9.0",
 				"micromatch": "^3.1.10",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7"
 			},
 			"dependencies": {
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"dev": true,
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					}
-				},
 				"graceful-fs": {
-					"version": "4.1.15",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 					"dev": true
 				}
 			}
 		},
 		"jest-jasmine2": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
-			"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+			"integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
 			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
-				"expect": "^24.8.0",
+				"expect": "^24.9.0",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"pretty-format": "^24.8.0",
+				"jest-each": "^24.9.0",
+				"jest-matcher-utils": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-snapshot": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"pretty-format": "^24.9.0",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-leak-detector": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
-			"integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+			"integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^24.8.0"
+				"jest-get-type": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
-			"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+			"integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"jest-diff": "^24.8.0",
-				"jest-get-type": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"jest-diff": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-message-util": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
-			"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+			"integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"@types/stack-utils": "^1.0.1",
 				"chalk": "^2.0.1",
 				"micromatch": "^3.1.10",
@@ -6265,12 +5052,12 @@
 			}
 		},
 		"jest-mock": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
-			"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
+			"integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0"
+				"@jest/types": "^24.9.0"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -6280,18 +5067,18 @@
 			"dev": true
 		},
 		"jest-regex-util": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
-			"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+			"integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
-			"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
+			"integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"browser-resolve": "^1.11.3",
 				"chalk": "^2.0.1",
 				"jest-pnp-resolver": "^1.2.1",
@@ -6299,127 +5086,136 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
-			"integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+			"integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-snapshot": "^24.8.0"
+				"jest-snapshot": "^24.9.0"
 			}
 		},
 		"jest-runner": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
-			"integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
+			"integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
 			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.4.2",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.8.0",
+				"jest-config": "^24.9.0",
 				"jest-docblock": "^24.3.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-jasmine2": "^24.8.0",
-				"jest-leak-detector": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-resolve": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-util": "^24.8.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-jasmine2": "^24.9.0",
+				"jest-leak-detector": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-resolve": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"jest-worker": "^24.6.0",
 				"source-map-support": "^0.5.6",
 				"throat": "^4.0.0"
 			},
 			"dependencies": {
 				"graceful-fs": {
-					"version": "4.1.15",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 					"dev": true
 				}
 			}
 		},
 		"jest-runtime": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
-			"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
+			"integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
 			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.8.0",
+				"@jest/environment": "^24.9.0",
 				"@jest/source-map": "^24.3.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"@types/yargs": "^12.0.2",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"@types/yargs": "^13.0.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-mock": "^24.8.0",
+				"jest-config": "^24.9.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-mock": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
+				"jest-resolve": "^24.9.0",
+				"jest-snapshot": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-validate": "^24.9.0",
 				"realpath-native": "^1.1.0",
 				"slash": "^2.0.0",
 				"strip-bom": "^3.0.0",
-				"yargs": "^12.0.2"
+				"yargs": "^13.3.0"
 			},
 			"dependencies": {
 				"graceful-fs": {
-					"version": "4.1.15",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 					"dev": true
 				}
 			}
 		},
 		"jest-serializer": {
-			"version": "24.4.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
-			"integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
+			"integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
 			"dev": true
 		},
 		"jest-snapshot": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
-			"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+			"integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
-				"expect": "^24.8.0",
-				"jest-diff": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-resolve": "^24.8.0",
+				"expect": "^24.9.0",
+				"jest-diff": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"jest-matcher-utils": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-resolve": "^24.9.0",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^24.8.0",
-				"semver": "^5.5.0"
+				"pretty-format": "^24.9.0",
+				"semver": "^6.2.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"jest-util": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
-			"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
+			"integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/source-map": "^24.3.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/console": "^24.9.0",
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/source-map": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"callsites": "^3.0.0",
 				"chalk": "^2.0.1",
 				"graceful-fs": "^4.1.15",
@@ -6430,9 +5226,9 @@
 			},
 			"dependencies": {
 				"graceful-fs": {
-					"version": "4.1.15",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 					"dev": true
 				},
 				"source-map": {
@@ -6444,41 +5240,41 @@
 			}
 		},
 		"jest-validate": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
-			"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
+			"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"camelcase": "^5.0.0",
+				"@jest/types": "^24.9.0",
+				"camelcase": "^5.3.1",
 				"chalk": "^2.0.1",
-				"jest-get-type": "^24.8.0",
-				"leven": "^2.1.0",
-				"pretty-format": "^24.8.0"
+				"jest-get-type": "^24.9.0",
+				"leven": "^3.1.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-watcher": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
-			"integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
+			"integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"@types/yargs": "^12.0.9",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"@types/yargs": "^13.0.0",
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.1",
-				"jest-util": "^24.8.0",
+				"jest-util": "^24.9.0",
 				"string-length": "^2.0.0"
 			}
 		},
 		"jest-worker": {
-			"version": "24.6.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
-			"integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
 			"dev": true,
 			"requires": {
-				"merge-stream": "^1.0.1",
+				"merge-stream": "^2.0.0",
 				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
@@ -6502,7 +5298,8 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"jsbn": {
 			"version": "0.1.1",
@@ -6574,6 +5371,23 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
+		"json5": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6601,15 +5415,6 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
-		"lcid": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-			"dev": true,
-			"requires": {
-				"invert-kv": "^2.0.0"
-			}
-		},
 		"left-pad": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -6617,9 +5422,9 @@
 			"dev": true
 		},
 		"leven": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
 			"dev": true
 		},
 		"levn": {
@@ -6670,6 +5475,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -6707,15 +5513,6 @@
 				"tmpl": "1.0.x"
 			}
 		},
-		"map-age-cleaner": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-			"dev": true,
-			"requires": {
-				"p-defer": "^1.0.0"
-			}
-		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -6731,30 +5528,16 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"mem": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-			"dev": true,
-			"requires": {
-				"map-age-cleaner": "^0.1.1",
-				"mimic-fn": "^2.0.0",
-				"p-is-promise": "^2.0.0"
-			}
-		},
 		"memoize-one": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
-			"integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+			"integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
 		},
 		"merge-stream": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.1"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "3.1.10",
@@ -6786,25 +5569,19 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+			"integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"version": "2.1.25",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+			"integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.40.0"
+				"mime-db": "1.42.0"
 			}
-		},
-		"mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -6921,15 +5698,6 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
-			}
-		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6943,9 +5711,9 @@
 			"dev": true
 		},
 		"node-notifier": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
-			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+			"integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
 			"dev": true,
 			"requires": {
 				"growly": "^1.3.0",
@@ -6956,12 +5724,20 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.21",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
-			"integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
+			"version": "1.1.40",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.40.tgz",
+			"integrity": "sha512-r4LPcC5b/bS8BdtWH1fbeK88ib/wg9aqmg6/s3ngNLn2Ewkn/8J6Iw3P9RTlfIAdSdvYvQl2thCY5Y+qTAQ2iQ==",
 			"dev": true,
 			"requires": {
-				"semver": "^5.3.0"
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"normalize-package-data": {
@@ -6994,16 +5770,10 @@
 				"path-key": "^2.0.0"
 			}
 		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
-		},
 		"nwsapi": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
-			"integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
 			"dev": true
 		},
 		"oauth-sign": {
@@ -7011,11 +5781,6 @@
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -7039,6 +5804,12 @@
 				}
 			}
 		},
+		"object-inspect": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"dev": true
+		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -7052,6 +5823,18 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
+			}
+		},
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -7093,43 +5876,18 @@
 			}
 		},
 		"optionator": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
 			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
+				"fast-levenshtein": "~2.0.6",
 				"levn": "~0.3.0",
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
-			},
-			"dependencies": {
-				"wordwrap": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-					"dev": true
-				}
+				"word-wrap": "~1.2.3"
 			}
-		},
-		"os-locale": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-			"dev": true,
-			"requires": {
-				"execa": "^1.0.0",
-				"lcid": "^2.0.0",
-				"mem": "^4.0.0"
-			}
-		},
-		"p-defer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-			"dev": true
 		},
 		"p-each-series": {
 			"version": "1.0.0",
@@ -7146,16 +5904,10 @@
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 			"dev": true
 		},
-		"p-is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-			"dev": true
-		},
 		"p-limit": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+			"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
@@ -7293,12 +6045,12 @@
 			"dev": true
 		},
 		"pretty-format": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
-			"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"ansi-regex": "^4.0.0",
 				"ansi-styles": "^3.2.0",
 				"react-is": "^16.8.4"
@@ -7314,39 +6066,23 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-			"dev": true
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "~2.0.3"
-			}
+			"dev": true,
+			"optional": true
 		},
 		"prompts": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
-			"integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
+			"integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
 			"dev": true,
 			"requires": {
-				"kleur": "^3.0.2",
-				"sisteransi": "^1.0.0"
-			}
-		},
-		"prop-types": {
-			"version": "15.6.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-			"requires": {
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.3"
 			}
 		},
 		"psl": {
-			"version": "1.1.32",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-			"integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
 			"dev": true
 		},
 		"pump": {
@@ -7372,9 +6108,9 @@
 			"dev": true
 		},
 		"react-is": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
 			"dev": true
 		},
 		"read-pkg": {
@@ -7403,6 +6139,7 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -7411,6 +6148,18 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
+			}
+		},
+		"readdirp": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"micromatch": "^3.1.10",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"realpath-native": {
@@ -7442,6 +6191,15 @@
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
 			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 		},
+		"regenerator-transform": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+			"integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+			"dev": true,
+			"requires": {
+				"private": "^0.1.6"
+			}
+		},
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -7452,11 +6210,42 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"regexp-tree": {
-			"version": "0.1.10",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.10.tgz",
-			"integrity": "sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ==",
+		"regexpu-core": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+			"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+			"dev": true,
+			"requires": {
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^8.1.0",
+				"regjsgen": "^0.5.0",
+				"regjsparser": "^0.6.0",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.1.0"
+			}
+		},
+		"regjsgen": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
 			"dev": true
+		},
+		"regjsparser": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+			"dev": true,
+			"requires": {
+				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				}
+			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -7523,21 +6312,21 @@
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+			"integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.15"
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+			"integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
 			"dev": true,
 			"requires": {
-				"request-promise-core": "1.1.2",
+				"request-promise-core": "1.1.3",
 				"stealthy-require": "^1.1.1",
 				"tough-cookie": "^2.3.3"
 			}
@@ -7591,18 +6380,18 @@
 			"dev": true
 		},
 		"rimraf": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
 		},
 		"rsvp": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
-			"integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+			"version": "4.8.5",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
 			"dev": true
 		},
 		"safe-buffer": {
@@ -7623,7 +6412,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -7642,16 +6432,6 @@
 				"walker": "~1.0.5"
 			},
 			"dependencies": {
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"dev": true,
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					}
-				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -7701,11 +6481,6 @@
 				}
 			}
 		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -7734,9 +6509,9 @@
 			"dev": true
 		},
 		"sisteransi": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
-			"integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
+			"integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==",
 			"dev": true
 		},
 		"slash": {
@@ -7867,9 +6642,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.12",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-			"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -7917,9 +6692,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-			"integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
 			"dev": true
 		},
 		"split-string": {
@@ -8009,30 +6784,34 @@
 			}
 		},
 		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 			"dev": true,
 			"requires": {
+				"emoji-regex": "^7.0.1",
 				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
+				"strip-ansi": "^5.1.0"
+			}
+		},
+		"string.prototype.trimleft": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"string.prototype.trimright": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"string_decoder": {
@@ -8040,6 +6819,7 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -8075,9 +6855,9 @@
 			}
 		},
 		"symbol-tree": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
 		},
 		"test-exclude": {
@@ -8097,11 +6877,6 @@
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 			"dev": true
-		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"tmpl": {
 			"version": "1.0.4",
@@ -8176,12 +6951,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"trim-right": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
-		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -8206,15 +6975,10 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
-		"ua-parser-js": {
-			"version": "0.7.18",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
-		},
 		"uglify-js": {
-			"version": "3.6.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
-			"integrity": "sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==",
+			"version": "3.6.9",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+			"integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -8222,13 +6986,6 @@
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true,
-					"optional": true
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8319,9 +7076,9 @@
 			}
 		},
 		"upath": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
 			"dev": true,
 			"optional": true
 		},
@@ -8350,7 +7107,8 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"util.promisify": {
 			"version": "1.0.0",
@@ -8363,9 +7121,9 @@
 			}
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -8422,11 +7180,6 @@
 				"iconv-lite": "0.4.24"
 			}
 		},
-		"whatwg-fetch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
-		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -8459,6 +7212,12 @@
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
 		},
+		"word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"dev": true
+		},
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -8466,50 +7225,14 @@
 			"dev": true
 		},
 		"wrap-ansi": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
+				"ansi-styles": "^3.2.0",
+				"string-width": "^3.0.0",
+				"strip-ansi": "^5.0.0"
 			}
 		},
 		"wrappy": {
@@ -8551,37 +7274,27 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "12.0.5",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+			"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
 			"dev": true,
 			"requires": {
-				"cliui": "^4.0.0",
-				"decamelize": "^1.2.0",
+				"cliui": "^5.0.0",
 				"find-up": "^3.0.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^3.0.0",
+				"get-caller-file": "^2.0.1",
 				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
+				"require-main-filename": "^2.0.0",
 				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
+				"string-width": "^3.0.0",
 				"which-module": "^2.0.0",
-				"y18n": "^3.2.1 || ^4.0.0",
-				"yargs-parser": "^11.1.1"
-			},
-			"dependencies": {
-				"require-main-filename": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
-				}
+				"y18n": "^4.0.0",
+				"yargs-parser": "^13.1.1"
 			}
 		},
 		"yargs-parser": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+			"version": "13.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+			"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -34,22 +34,20 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@babel/cli": "^7.4.4",
-    "@babel/core": "^7.4.5",
-    "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
-    "@babel/plugin-transform-runtime": "^7.4.4",
-    "@babel/preset-env": "^7.4.5",
-    "@babel/preset-react": "^7.0.0",
+    "@babel/cli": "^7.7.0",
+    "@babel/core": "^7.7.2",
+    "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+    "@babel/plugin-transform-runtime": "^7.6.2",
+    "@babel/preset-env": "^7.7.1",
+    "@babel/preset-react": "^7.7.0",
     "has-resolved": "^1.1.0",
-    "jest": "^24.8.0",
-    "rimraf": "^2.6.3"
+    "jest": "^24.9.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.6.3",
+    "@babel/runtime": "^7.7.2",
     "classnames": "^2.2.6",
     "event-as-promise": "^1.0.5",
-    "glamor": "^2.20.40",
-    "memoize-one": "^5.0.4"
+    "memoize-one": "^5.1.1"
   },
   "peerDependencies": {
     "react": "^16.8.6"


### PR DESCRIPTION
## Changelog

### Breaking changes

- Now requires React 16.8.6 or up

### Changed

- Bumped dependencies in [PR #18](https://github.com/compulim/react-say/pull/18)
   - [`@babel/cli@7.7.0`](https://npmjs.com/package/@babel/cli)
   - [`@babel/core@7.7.2`](https://npmjs.com/package/@babel/core)
   - [`@babel/plugin-proposal-object-rest-spread@7.6.2`](https://npmjs.com/package/@babel/plugin-proposal-object-rest-spread)
   - [`@babel/plugin-transform-runtime@7.6.2`](https://npmjs.com/package/@babel/plugin-transform-runtime)
   - [`@babel/preset-env@7.7.1`](https://npmjs.com/package/@babel/preset-env)
   - [`@babel/preset-react@7.7.0`](https://npmjs.com/package/@babel/preset-react)
   - [`@babel/runtime@7.7.2`](https://npmjs.com/package/@babel/runtime)
   - [`jest@24.9.0`](https://npmjs.com/package/jest)
   - [`memoize-one@5.1.1`](https://npmjs.com/package/memoize-one)
