### PR TITLE
Use `new CustomEvent()` and fallback to `document.createEvent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Use `new CustomEvent()` and fallback to `document.createElement` for custom events, by [@compulim](https://github.com/compulim), in PR [#22](https://github.com/compulim/react-say/pull/22)
+
+### Fixed
+
 ## [2.0.0] - 2019-11-19
 
 ### Breaking changes

--- a/packages/component/src/QueuedUtterance.js
+++ b/packages/component/src/QueuedUtterance.js
@@ -1,3 +1,4 @@
+import createCustomEvent from './createCustomEvent';
 import createDeferred from './createDeferred';
 import createErrorEvent from './createErrorEvent';
 
@@ -93,7 +94,7 @@ export default class QueuedUtterance {
           throw new Error('cancelled');
         } else {
           this._cancel = cancel;
-          this._onStart && this._onStart(new Event('start'));
+          this._onStart && this._onStart(createCustomEvent('start'));
         }
       });
 
@@ -101,7 +102,7 @@ export default class QueuedUtterance {
         throw new Error('cancelled');
       }
     })().then(() => {
-      this._onEnd && this._onEnd(new Event('end'));
+      this._onEnd && this._onEnd(createCustomEvent('end'));
       this._deferred.resolve();
     }, error => {
       this._onError && this._onError(createErrorEvent(error));

--- a/packages/component/src/SayUtterance.js
+++ b/packages/component/src/SayUtterance.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useRef } from 'react';
 
 import Composer from './Composer';
+import createCustomEvent from './createCustomEvent';
 import createErrorEvent from './createErrorEvent';
 import migrateDeprecatedProps from './migrateDeprecatedProps';
 import useSynthesize from './useSynthesize';
@@ -31,11 +32,11 @@ const SayUtterance = props => {
     let cancelled;
     const { cancel, promise } = synthesize(utterance, () => {
       started.current = true;
-      !cancelled && onStart && onStart(new Event('start'));
+      !cancelled && onStart && onStart(createCustomEvent('start'));
     });
 
     promise.then(
-      () => !cancelled && onEnd && onEnd(new Event('end')),
+      () => !cancelled && onEnd && onEnd(createCustomEvent('end')),
       error => !cancelled && onError && onError(createErrorEvent(error))
     );
 

--- a/packages/component/src/createCustomEvent.js
+++ b/packages/component/src/createCustomEvent.js
@@ -1,0 +1,15 @@
+export default function createCustomEvent(name, eventInitDict) {
+  if (typeof CustomEvent === 'function') {
+    return new CustomEvent(name, eventInitDict);
+  }
+
+  const event = document.createEvent('Event');
+
+  event.initEvent(name, true, true);
+
+  Object.entries(eventInitDict).forEach(([key, value]) => {
+    event[key] = value;
+  });
+
+  return event;
+}

--- a/packages/component/src/createCustomEvent.js
+++ b/packages/component/src/createCustomEvent.js
@@ -1,5 +1,9 @@
 export default function createCustomEvent(name, eventInitDict) {
-  if (typeof CustomEvent === 'function') {
+  if (name === 'error') {
+    if (typeof ErrorEvent === 'function') {
+      return new ErrorEvent(name, eventInitDict);
+    }
+  } else if (typeof CustomEvent === 'function') {
     return new CustomEvent(name, eventInitDict);
   }
 

--- a/packages/component/src/createErrorEvent.js
+++ b/packages/component/src/createErrorEvent.js
@@ -1,7 +1,5 @@
+import createCustomEvent from './createCustomEvent';
+
 export default function createErrorEvent(error) {
-  const event = new Event('error');
-
-  event.error = error;
-
-  return event;
+  return createCustomEvent('error', { error });
 }


### PR DESCRIPTION
This is for supporting IE11 without breaking it.

In IE11, `Event.prototype.constructor` is not a function. Thus, `new Event()` is not possible. We should use the now-deprecated `document.createEvent('Event')` instead.